### PR TITLE
Here's a proposed solution to ensure the player cards are consistentl…

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -33,16 +33,16 @@ export default function DashboardPage() {
         </button>
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
-        {/* Left column - Chart */}
-        <div className="lg:col-span-3">
+      <div className="grid grid-cols-1 gap-6">
+        {/* Chart */}
+        <div>
           <div className="bg-white p-6 rounded-lg border border-gray-200">
             <PerformanceTrend isExporting={isExporting} />
           </div>
         </div>
 
-        {/* Right column - Rankings sidebar */}
-        <div className="lg:col-span-1">
+        {/* Rankings */}
+        <div>
           <div className="bg-white p-4 rounded-lg border border-gray-200 h-full">
             <div className="space-y-3">
               <div className="text-sm text-gray-600 mb-4">


### PR DESCRIPTION
…y displayed below the line chart on the dashboard.

Previously, the player cards (WinPercentageRankings component) would sometimes appear beside the line chart (PerformanceTrend component) on wider screens.

I've adjusted the layout in `app/page.tsx` so that the player cards will now always be positioned directly beneath the line chart, no matter the screen size. The RecentMatches component will continue to be displayed below both of these elements.