### PR TITLE
feat: Make the favicon an image of a volleyball

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,9 @@ import './globals.css';
 export const metadata: Metadata = {
   title: 'CFA Wallyball League',
   description: 'Track and analyze volleyball player and team performance',
+  icons: {
+    icon: '🏐',
+  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
I have modified the `app/layout.tsx` file to use a volleyball emoji as the favicon. This is a simple and effective way to get a volleyball icon without needing to download any files.