### PR TITLE
feat: add weekly signups and admin configuration

### DIFF
--- a/agent-context/data-model.json
+++ b/agent-context/data-model.json
@@ -231,6 +231,7 @@
       "migrationTouchpoints": [
         "migrations/0000_light_toro.sql",
         "migrations/004_add_inactivity_exemptions.sql",
+        "migrations/007_add_signups.sql",
         "migrations/relations.ts",
         "migrations/schema.ts"
       ]
@@ -272,7 +273,9 @@
       ],
       "selectType": "SiteSetting",
       "insertType": "NewSiteSetting",
-      "migrationTouchpoints": []
+      "migrationTouchpoints": [
+        "migrations/007_add_signups.sql"
+      ]
     },
     {
       "symbol": "weeklySignups",
@@ -311,7 +314,9 @@
       ],
       "selectType": "WeeklySignup",
       "insertType": "NewWeeklySignup",
-      "migrationTouchpoints": []
+      "migrationTouchpoints": [
+        "migrations/007_add_signups.sql"
+      ]
     }
   ]
 }

--- a/agent-context/data-model.json
+++ b/agent-context/data-model.json
@@ -234,6 +234,84 @@
         "migrations/relations.ts",
         "migrations/schema.ts"
       ]
+    },
+    {
+      "symbol": "siteSettings",
+      "table": "site_settings",
+      "columns": [
+        {
+          "field": "id",
+          "kind": "serial",
+          "column": "id",
+          "references": null
+        },
+        {
+          "field": "adminPasswordHash",
+          "kind": "text",
+          "column": "admin_password_hash",
+          "references": null
+        },
+        {
+          "field": "signupOpenDayOfWeek",
+          "kind": "integer",
+          "column": "signup_open_day_of_week",
+          "references": null
+        },
+        {
+          "field": "signupOpenTime",
+          "kind": "text",
+          "column": "signup_open_time",
+          "references": null
+        },
+        {
+          "field": "availableDays",
+          "kind": "text",
+          "column": "available_days",
+          "references": null
+        }
+      ],
+      "selectType": "SiteSetting",
+      "insertType": "NewSiteSetting",
+      "migrationTouchpoints": []
+    },
+    {
+      "symbol": "weeklySignups",
+      "table": "weekly_signups",
+      "columns": [
+        {
+          "field": "id",
+          "kind": "serial",
+          "column": "id",
+          "references": null
+        },
+        {
+          "field": "playerId",
+          "kind": "integer",
+          "column": "player_id",
+          "references": "players"
+        },
+        {
+          "field": "date",
+          "kind": "text",
+          "column": "date",
+          "references": null
+        },
+        {
+          "field": "status",
+          "kind": "text",
+          "column": "status",
+          "references": null
+        },
+        {
+          "field": "createdAt",
+          "kind": "timestamp",
+          "column": "created_at",
+          "references": null
+        }
+      ],
+      "selectType": "WeeklySignup",
+      "insertType": "NewWeeklySignup",
+      "migrationTouchpoints": []
     }
   ]
 }

--- a/agent-context/graph.json
+++ b/agent-context/graph.json
@@ -32,6 +32,15 @@
       "overrideNotes": []
     },
     {
+      "file": "app/api/auth/route.ts",
+      "type": "api-route",
+      "tags": [],
+      "imports": [],
+      "importedBy": [],
+      "related": [],
+      "overrideNotes": []
+    },
+    {
       "file": "app/api/chatbot/image/route.ts",
       "type": "api-route",
       "tags": [
@@ -273,6 +282,24 @@
       "overrideNotes": []
     },
     {
+      "file": "app/api/settings/route.ts",
+      "type": "api-route",
+      "tags": [],
+      "imports": [],
+      "importedBy": [],
+      "related": [],
+      "overrideNotes": []
+    },
+    {
+      "file": "app/api/signups/route.ts",
+      "type": "api-route",
+      "tags": [],
+      "imports": [],
+      "importedBy": [],
+      "related": [],
+      "overrideNotes": []
+    },
+    {
       "file": "app/api/team-performance/route.ts",
       "type": "api-route",
       "tags": [
@@ -299,6 +326,21 @@
       "imports": [],
       "importedBy": [],
       "related": [],
+      "overrideNotes": []
+    },
+    {
+      "file": "app/components/AdminLoginModal.tsx",
+      "type": "component",
+      "tags": [],
+      "imports": [],
+      "importedBy": [
+        "app/settings/page.tsx",
+        "app/signups/page.tsx"
+      ],
+      "related": [
+        "app/settings/page.tsx",
+        "app/signups/page.tsx"
+      ],
       "overrideNotes": []
     },
     {
@@ -961,6 +1003,32 @@
         "app/components/PlayerCards.tsx",
         "app/components/SeasonWinners.tsx",
         "app/components/TopTeams.tsx"
+      ],
+      "overrideNotes": []
+    },
+    {
+      "file": "app/settings/page.tsx",
+      "type": "page",
+      "tags": [],
+      "imports": [
+        "app/components/AdminLoginModal.tsx"
+      ],
+      "importedBy": [],
+      "related": [
+        "app/components/AdminLoginModal.tsx"
+      ],
+      "overrideNotes": []
+    },
+    {
+      "file": "app/signups/page.tsx",
+      "type": "page",
+      "tags": [],
+      "imports": [
+        "app/components/AdminLoginModal.tsx"
+      ],
+      "importedBy": [],
+      "related": [
+        "app/components/AdminLoginModal.tsx"
       ],
       "overrideNotes": []
     },

--- a/agent-context/index.json
+++ b/agent-context/index.json
@@ -8,7 +8,7 @@
       "agent-context/index.json",
       "agent-context/tasks.json"
     ],
-    "routeCount": 23,
+    "routeCount": 28,
     "taskCount": 6
   },
   "commands": [
@@ -51,12 +51,12 @@
       "files": [
         "app/api/achievements/check/[playerId]/route.ts",
         "app/api/achievements/player/[playerId]/route.ts",
+        "app/api/auth/route.ts",
         "app/api/chatbot/route.ts",
         "app/api/chatbot/image/route.ts",
         "app/api/daily-summary/route.ts",
         "app/api/feedback/route.ts",
-        "app/api/games/route.ts",
-        "app/api/games/[id]/route.ts"
+        "app/api/games/route.ts"
       ]
     },
     {

--- a/agent-context/routes.json
+++ b/agent-context/routes.json
@@ -40,6 +40,13 @@
     },
     {
       "kind": "api",
+      "route": "/api/auth",
+      "file": "app/api/auth/route.ts",
+      "params": [],
+      "likelySourceFiles": []
+    },
+    {
+      "kind": "api",
       "route": "/api/chatbot",
       "file": "app/api/chatbot/route.ts",
       "params": [],
@@ -171,6 +178,20 @@
     },
     {
       "kind": "api",
+      "route": "/api/settings",
+      "file": "app/api/settings/route.ts",
+      "params": [],
+      "likelySourceFiles": []
+    },
+    {
+      "kind": "api",
+      "route": "/api/signups",
+      "file": "app/api/signups/route.ts",
+      "params": [],
+      "likelySourceFiles": []
+    },
+    {
+      "kind": "api",
       "route": "/api/team-performance",
       "file": "app/api/team-performance/route.ts",
       "params": [],
@@ -218,6 +239,24 @@
         "app/components/SeasonWinners.tsx",
         "app/components/TopTeams.tsx",
         "app/components/ui/card.tsx"
+      ]
+    },
+    {
+      "kind": "page",
+      "route": "/settings",
+      "file": "app/settings/page.tsx",
+      "params": [],
+      "likelySourceFiles": [
+        "app/components/AdminLoginModal.tsx"
+      ]
+    },
+    {
+      "kind": "page",
+      "route": "/signups",
+      "file": "app/signups/page.tsx",
+      "params": [],
+      "likelySourceFiles": [
+        "app/components/AdminLoginModal.tsx"
       ]
     }
   ]

--- a/app/api/auth/route.ts
+++ b/app/api/auth/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+import { neon } from '@neondatabase/serverless';
+import { cookies } from 'next/headers';
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    
+    if (!process.env.DATABASE_URL) {
+      throw new Error('Database URL not configured');
+    }
+    
+    const sql = neon(process.env.DATABASE_URL);
+    
+    // Check if site_settings exists
+    const settings = await sql`SELECT admin_password_hash FROM site_settings LIMIT 1`;
+    
+    let isValid = false;
+    
+    if (settings.length > 0 && settings[0].admin_password_hash) {
+      // Simple string comparison for light security
+      isValid = body.password === settings[0].admin_password_hash;
+    } else {
+      // Fallback if settings table is empty
+      isValid = body.password === (process.env.ADMIN_PASSWORD || 'admin');
+    }
+
+    if (isValid) {
+      const cookieStore = cookies();
+      cookieStore.set('admin_token', 'true', {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'strict',
+        maxAge: 60 * 60 * 24 * 7 // 1 week
+      });
+      return NextResponse.json({ success: true });
+    }
+    
+    return NextResponse.json({ error: 'Invalid password' }, { status: 401 });
+  } catch (error) {
+    console.error('Error in auth:', error);
+    return NextResponse.json({ error: 'Failed to authenticate' }, { status: 500 });
+  }
+}

--- a/app/api/matches/[id]/route.ts
+++ b/app/api/matches/[id]/route.ts
@@ -1,5 +1,6 @@
 
 import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
 import { neon } from '@neondatabase/serverless';
 
 export async function GET(
@@ -81,6 +82,10 @@ export async function PUT(
 ) {
   const resolvedParams = await params;
   const matchId = parseInt(resolvedParams.id);
+  
+  const isAdmin = cookies().get('admin_token')?.value === 'true';
+  if (!isAdmin) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
   const body = await request.json();
 
   if (isNaN(matchId)) {
@@ -171,6 +176,9 @@ export async function DELETE(
 ) {
   const resolvedParams = await params;
   const matchId = parseInt(resolvedParams.id);
+
+  const isAdmin = cookies().get('admin_token')?.value === 'true';
+  if (!isAdmin) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
   if (isNaN(matchId)) {
     return NextResponse.json(

--- a/app/api/matches/route.ts
+++ b/app/api/matches/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
 import { neon } from '@neondatabase/serverless';
 
 export async function GET(request: Request) {
@@ -108,6 +109,9 @@ async function getPlayerIdsFromNames(sql: any, playerNames: string[]) {
 
 export async function POST(request: Request) {
   try {
+    const isAdmin = cookies().get('admin_token')?.value === 'true';
+    if (!isAdmin) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
     const body = await request.json();
 
     if (!process.env.DATABASE_URL) {

--- a/app/api/players/route.ts
+++ b/app/api/players/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
 import { neon } from '@neondatabase/serverless';
 
 export async function GET() {
@@ -80,6 +81,9 @@ export async function GET() {
 
 export async function POST(request: Request) {
   try {
+    const isAdmin = cookies().get('admin_token')?.value === 'true';
+    if (!isAdmin) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
     const body = await request.json();
     
     // Validation
@@ -127,6 +131,9 @@ export async function POST(request: Request) {
 
 export async function PUT(request: Request) {
   try {
+    const isAdmin = cookies().get('admin_token')?.value === 'true';
+    if (!isAdmin) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
     const body = await request.json();
     
     // Validation
@@ -187,6 +194,9 @@ export async function PUT(request: Request) {
 
 export async function DELETE(request: Request) {
   try {
+    const isAdmin = cookies().get('admin_token')?.value === 'true';
+    if (!isAdmin) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
     const url = new URL(request.url);
     const id = url.searchParams.get('id');
     

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -1,0 +1,89 @@
+import { NextResponse } from 'next/server';
+import { neon } from '@neondatabase/serverless';
+import { cookies } from 'next/headers';
+
+export async function GET() {
+  try {
+    if (!process.env.DATABASE_URL) {
+      throw new Error('Database URL not configured');
+    }
+    
+    const sql = neon(process.env.DATABASE_URL);
+    
+    // Fetch settings or return defaults
+    const settings = await sql`SELECT * FROM site_settings LIMIT 1`;
+    
+    if (settings.length > 0) {
+      return NextResponse.json({
+        signupOpenDayOfWeek: settings[0].signup_open_day_of_week,
+        signupOpenTime: settings[0].signup_open_time,
+        availableDays: JSON.parse(settings[0].available_days || '["Monday", "Tuesday", "Thursday"]')
+      });
+    }
+    
+    // Defaults matching our schema
+    return NextResponse.json({
+      signupOpenDayOfWeek: 0, // Sunday
+      signupOpenTime: '12:00', // Noon
+      availableDays: ["Monday", "Tuesday", "Thursday"]
+    });
+  } catch (error) {
+    console.error('Error fetching settings:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch settings' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PUT(request: Request) {
+  try {
+    // Check admin auth
+    const cookieStore = cookies();
+    const isAdmin = cookieStore.get('admin_token')?.value === 'true';
+    if (!isAdmin) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = await request.json();
+    
+    if (!process.env.DATABASE_URL) {
+      throw new Error('Database URL not configured');
+    }
+    
+    const sql = neon(process.env.DATABASE_URL);
+
+    // Upsert logic for site_settings
+    const existing = await sql`SELECT id FROM site_settings LIMIT 1`;
+    
+    if (existing.length > 0) {
+      await sql`
+        UPDATE site_settings 
+        SET 
+          signup_open_day_of_week = COALESCE(${body.signupOpenDayOfWeek}, signup_open_day_of_week),
+          signup_open_time = COALESCE(${body.signupOpenTime}, signup_open_time),
+          available_days = COALESCE(${JSON.stringify(body.availableDays)}, available_days),
+          admin_password_hash = COALESCE(${body.adminPassword}, admin_password_hash)
+        WHERE id = ${existing[0].id}
+      `;
+    } else {
+      await sql`
+        INSERT INTO site_settings (signup_open_day_of_week, signup_open_time, available_days, admin_password_hash)
+        VALUES (
+          ${body.signupOpenDayOfWeek ?? 0}, 
+          ${body.signupOpenTime || '12:00'}, 
+          ${JSON.stringify(body.availableDays || ["Monday", "Tuesday", "Thursday"])},
+          ${body.adminPassword || 'admin'}
+        )
+      `;
+    }
+    
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Error updating settings:', error);
+    return NextResponse.json(
+      { error: 'Failed to update settings' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/signups/route.ts
+++ b/app/api/signups/route.ts
@@ -1,0 +1,167 @@
+import { NextResponse } from 'next/server';
+import { neon } from '@neondatabase/serverless';
+import { cookies } from 'next/headers';
+
+function getEstNow() {
+  return new Date(new Date().toLocaleString("en-US", {timeZone: "America/New_York"}));
+}
+
+function isSignupOpen(targetDateStr: string, openDayOfWeek: number, openTime: string) {
+  const targetDate = new Date(`${targetDateStr}T12:00:00-05:00`); // using roughly EST offset for date math
+  const [hours, minutes] = openTime.split(':').map(Number);
+  
+  // Find the Sunday that starts this target date's calendar week
+  const weekStartSunday = new Date(targetDate);
+  weekStartSunday.setDate(targetDate.getDate() - targetDate.getDay());
+  
+  // The signups for this calendar week open on the openDayOfWeek of the PRECEDING week
+  const openDateTime = new Date(weekStartSunday);
+  openDateTime.setDate(weekStartSunday.getDate() - 7 + openDayOfWeek);
+  openDateTime.setHours(hours, minutes, 0, 0);
+  
+  return getEstNow() >= openDateTime;
+}
+
+export async function GET(request: Request) {
+  try {
+    const url = new URL(request.url);
+    const dateParam = url.searchParams.get('date');
+    const playerParam = url.searchParams.get('playerId');
+    
+    if (!process.env.DATABASE_URL) throw new Error('Database URL not configured');
+    const sql = neon(process.env.DATABASE_URL);
+    
+    let signups;
+    if (dateParam) {
+      signups = await sql`
+        SELECT s.*, p.name 
+        FROM weekly_signups s
+        JOIN players p ON s.player_id = p.id
+        WHERE s.date = ${dateParam}
+        ORDER BY s.created_at ASC
+      `;
+    } else if (playerParam) {
+      signups = await sql`
+        SELECT s.*, p.name 
+        FROM weekly_signups s
+        JOIN players p ON s.player_id = p.id
+        WHERE s.player_id = ${playerParam} AND s.date::date >= current_date
+        ORDER BY s.date ASC
+      `;
+    } else {
+      signups = await sql`
+        SELECT s.*, p.name 
+        FROM weekly_signups s
+        JOIN players p ON s.player_id = p.id
+        WHERE s.date::date >= current_date - interval '7 days'
+        ORDER BY s.date ASC, s.created_at ASC
+      `;
+    }
+    
+    return NextResponse.json(signups);
+  } catch (error) {
+    console.error('Error fetching signups:', error);
+    return NextResponse.json({ error: 'Failed to fetch signups' }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { playerId, date } = body;
+    
+    if (!playerId || !date) {
+      return NextResponse.json({ error: 'playerId and date are required' }, { status: 400 });
+    }
+    
+    if (!process.env.DATABASE_URL) throw new Error('Database URL not configured');
+    const sql = neon(process.env.DATABASE_URL);
+
+    // Check if open
+    const settings = await sql`SELECT signup_open_day_of_week, signup_open_time FROM site_settings LIMIT 1`;
+    const isAdmin = cookies().get('admin_token')?.value === 'true';
+    
+    if (settings.length > 0 && !isAdmin) {
+      const { signup_open_day_of_week, signup_open_time } = settings[0];
+      if (!isSignupOpen(date, signup_open_day_of_week, signup_open_time)) {
+        return NextResponse.json({ error: 'Signups are not open yet for this date' }, { status: 403 });
+      }
+    }
+
+    // Check existing signup
+    const existing = await sql`SELECT id FROM weekly_signups WHERE player_id = ${playerId} AND date = ${date}`;
+    if (existing.length > 0) {
+      return NextResponse.json({ error: 'Player already signed up for this date' }, { status: 400 });
+    }
+
+    // Determine status based on current count
+    const countRes = await sql`SELECT count(*) as total FROM weekly_signups WHERE date = ${date} AND status = 'registered'`;
+    const count = parseInt(countRes[0].total, 10);
+    const status = count < 6 ? 'registered' : 'waitlisted';
+
+    const newSignup = await sql`
+      INSERT INTO weekly_signups (player_id, date, status)
+      VALUES (${playerId}, ${date}, ${status})
+      RETURNING *
+    `;
+
+    return NextResponse.json({ success: true, signup: newSignup[0] });
+  } catch (error) {
+    console.error('Error creating signup:', error);
+    return NextResponse.json({ error: 'Failed to sign up' }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: Request) {
+  try {
+    const body = await request.json();
+    const { id, playerId, date } = body;
+
+    if (!id && !(playerId && date)) {
+        return NextResponse.json({ error: 'id or (playerId and date) required' }, { status: 400 });
+    }
+
+    if (!process.env.DATABASE_URL) throw new Error('Database URL not configured');
+    const sql = neon(process.env.DATABASE_URL);
+
+    // Get the signup to check its status before deleting
+    let targetSignup;
+    if (id) {
+        targetSignup = await sql`SELECT * FROM weekly_signups WHERE id = ${id}`;
+    } else {
+        targetSignup = await sql`SELECT * FROM weekly_signups WHERE player_id = ${playerId} AND date = ${date}`;
+    }
+
+    if (targetSignup.length === 0) {
+        return NextResponse.json({ error: 'Signup not found' }, { status: 404 });
+    }
+
+    const { id: signupId, date: signupDate, status } = targetSignup[0];
+
+    // Delete it
+    await sql`DELETE FROM weekly_signups WHERE id = ${signupId}`;
+
+    // If it was registered, promote the first waitlisted person
+    if (status === 'registered') {
+        const waitlisted = await sql`
+            SELECT id FROM weekly_signups 
+            WHERE date = ${signupDate} AND status = 'waitlisted' 
+            ORDER BY created_at ASC 
+            LIMIT 1
+        `;
+        
+        if (waitlisted.length > 0) {
+            await sql`
+                UPDATE weekly_signups 
+                SET status = 'registered' 
+                WHERE id = ${waitlisted[0].id}
+            `;
+        }
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Error deleting signup:', error);
+    return NextResponse.json({ error: 'Failed to delete signup' }, { status: 500 });
+  }
+}

--- a/app/components/AdminLoginModal.tsx
+++ b/app/components/AdminLoginModal.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useState } from 'react';
+import { X } from 'lucide-react';
+
+interface AdminLoginModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export function AdminLoginModal({ isOpen, onClose, onSuccess }: AdminLoginModalProps) {
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  if (!isOpen) return null;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+    setError('');
+
+    try {
+      const response = await fetch('/api/auth', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ password }),
+      });
+
+      if (response.ok) {
+        setPassword('');
+        onSuccess();
+        onClose();
+      } else {
+        const data = await response.json();
+        setError(data.error || 'Invalid password');
+      }
+    } catch (err) {
+      setError('An error occurred. Please try again.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-50 p-4">
+      <div className="bg-white rounded-lg p-6 w-full max-w-md relative">
+        <button 
+          onClick={onClose}
+          className="absolute top-4 right-4 text-gray-500 hover:text-gray-700"
+        >
+          <X className="w-5 h-5" />
+        </button>
+        
+        <h2 className="text-xl font-bold mb-4">Admin Authentication Required</h2>
+        
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <label htmlFor="password" className="block text-sm font-medium text-gray-700">
+              Admin Password
+            </label>
+            <input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              className="w-full p-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="Enter admin password"
+            />
+          </div>
+          
+          {error && <p className="text-red-500 text-sm">{error}</p>}
+          
+          <div className="flex justify-end gap-2 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={isSubmitting}
+              className="px-4 py-2 border border-gray-300 text-gray-700 rounded-md hover:bg-gray-50 transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors disabled:opacity-50"
+            >
+              {isSubmitting ? 'Verifying...' : 'Submit'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -36,6 +36,18 @@ export function Navbar() {
           >
             Results
           </Link>
+          <Link 
+            href="/signups" 
+            className={`px-3 py-2 rounded ${isActive('/signups') ? 'bg-gray-700' : 'hover:bg-gray-800'}`}
+          >
+            Signups
+          </Link>
+          <Link 
+            href="/settings" 
+            className={`px-3 py-2 rounded ${isActive('/settings') ? 'bg-gray-700' : 'hover:bg-gray-800'}`}
+          >
+            Settings
+          </Link>
         </div>
       </div>
     </nav>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { AdminLoginModal } from '../components/AdminLoginModal';
-import { X, Check } from 'lucide-react';
+import { Check } from 'lucide-react';
 
 interface Settings {
   signupOpenDayOfWeek: number;
@@ -72,8 +72,12 @@ export default function SettingsPage() {
         const data = await response.json();
         throw new Error(data.error || 'Failed to save settings');
       }
-    } catch (error: any) {
-      setMessage({ text: error.message, type: 'error' });
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        setMessage({ text: error.message, type: 'error' });
+      } else {
+        setMessage({ text: String(error), type: 'error' });
+      }
     } finally {
       setIsSaving(false);
     }

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,194 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { AdminLoginModal } from '../components/AdminLoginModal';
+import { X, Check } from 'lucide-react';
+
+interface Settings {
+  signupOpenDayOfWeek: number;
+  signupOpenTime: string;
+  availableDays: string[];
+}
+
+const DAYS_OF_WEEK = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+
+export default function SettingsPage() {
+  const [settings, setSettings] = useState<Settings>({
+    signupOpenDayOfWeek: 0,
+    signupOpenTime: '12:00',
+    availableDays: ["Monday", "Tuesday", "Thursday"]
+  });
+  const [adminPassword, setAdminPassword] = useState('');
+  
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [showAdminModal, setShowAdminModal] = useState(false);
+  const [message, setMessage] = useState({ text: '', type: '' });
+
+  useEffect(() => {
+    const fetchSettings = async () => {
+      try {
+        const response = await fetch('/api/settings');
+        if (response.ok) {
+          const data = await response.json();
+          setSettings(data);
+        }
+      } catch (error) {
+        console.error('Failed to fetch settings:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchSettings();
+  }, []);
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    setMessage({ text: '', type: '' });
+
+    try {
+      const payload: Settings & { adminPassword?: string } = { ...settings };
+      if (adminPassword) {
+        payload.adminPassword = adminPassword;
+      }
+
+      const response = await fetch('/api/settings', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+
+      if (response.status === 401) {
+        setShowAdminModal(true);
+        setIsSaving(false);
+        return;
+      }
+
+      if (response.ok) {
+        setMessage({ text: 'Settings saved successfully!', type: 'success' });
+        setAdminPassword('');
+      } else {
+        const data = await response.json();
+        throw new Error(data.error || 'Failed to save settings');
+      }
+    } catch (error: any) {
+      setMessage({ text: error.message, type: 'error' });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleToggleAvailableDay = (day: string) => {
+    setSettings(prev => {
+      const currentDays = [...prev.availableDays];
+      if (currentDays.includes(day)) {
+         return { ...prev, availableDays: currentDays.filter(d => d !== day) };
+      } else {
+         return { ...prev, availableDays: [...currentDays, day] };
+      }
+    });
+  };
+
+  if (isLoading) return <div className="p-8 text-center text-gray-500">Loading settings...</div>;
+
+  return (
+    <div className="max-w-3xl mx-auto p-6 space-y-8">
+      <div className="border-b border-gray-200 pb-4">
+        <h1 className="text-2xl font-bold text-gray-800">Site Settings</h1>
+        <p className="text-gray-500 mt-1">Configure weekly signups and admin controls.</p>
+      </div>
+
+      {message.text && (
+        <div className={`p-4 rounded-md ${message.type === 'success' ? 'bg-green-50 text-green-800 border border-green-200' : 'bg-red-50 text-red-800 border border-red-200'}`}>
+          {message.text}
+        </div>
+      )}
+
+      <div className="bg-white p-6 rounded-lg border border-gray-200 space-y-6">
+        <h2 className="text-xl font-semibold mb-4 text-gray-800">Signup Configuration</h2>
+        
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div className="space-y-2">
+            <label className="block text-sm font-medium text-gray-700">Signups Open Day</label>
+            <select
+              value={settings.signupOpenDayOfWeek}
+              onChange={(e) => setSettings({...settings, signupOpenDayOfWeek: parseInt(e.target.value)})}
+              className="w-full p-2 border rounded-md focus:ring-2 focus:ring-blue-500 focus:outline-none"
+            >
+              {DAYS_OF_WEEK.map((day, idx) => (
+                <option key={day} value={idx}>{day}</option>
+              ))}
+            </select>
+          </div>
+
+          <div className="space-y-2">
+            <label className="block text-sm font-medium text-gray-700">Signups Open Time (EST)</label>
+            <input
+              type="time"
+              value={settings.signupOpenTime}
+              onChange={(e) => setSettings({...settings, signupOpenTime: e.target.value})}
+              className="w-full p-2 border rounded-md focus:ring-2 focus:ring-blue-500 focus:outline-none"
+            />
+          </div>
+        </div>
+
+        <div className="space-y-3 pt-4 border-t border-gray-100">
+          <label className="block text-sm font-medium text-gray-700">Available Days (Target Play Days)</label>
+          <div className="flex flex-wrap gap-2">
+            {DAYS_OF_WEEK.map(day => {
+              const isActive = settings.availableDays.includes(day);
+              return (
+                <button
+                  key={day}
+                  onClick={() => handleToggleAvailableDay(day)}
+                  className={`px-4 py-2 border rounded-full flex items-center gap-2 transition-colors
+                    ${isActive ? 'bg-blue-50 border-blue-500 text-blue-700' : 'bg-gray-50 border-gray-300 text-gray-600 hover:bg-gray-100'}
+                  `}
+                >
+                  {isActive && <Check className="w-4 h-4" />}
+                  {day}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      <div className="bg-white p-6 rounded-lg border border-gray-200 space-y-6">
+        <h2 className="text-xl font-semibold mb-4 text-gray-800">Admin Controls</h2>
+        
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-gray-700">Change Admin Password</label>
+          <input
+            type="password"
+            value={adminPassword}
+            onChange={(e) => setAdminPassword(e.target.value)}
+            placeholder="Leave blank to keep current password"
+            className="w-full p-2 border rounded-md focus:ring-2 focus:ring-blue-500 focus:outline-none max-w-sm"
+          />
+          <p className="text-sm text-gray-500 pt-1">You will be prompted for your current admin password when saving changes.</p>
+        </div>
+      </div>
+
+      <div className="flex justify-end">
+        <button
+          onClick={handleSave}
+          disabled={isSaving}
+          className="px-6 py-2 bg-blue-600 text-white font-medium rounded-md hover:bg-blue-700 transition-colors disabled:opacity-50"
+        >
+          {isSaving ? 'Saving...' : 'Save All Settings'}
+        </button>
+      </div>
+
+      <AdminLoginModal
+        isOpen={showAdminModal}
+        onClose={() => setShowAdminModal(false)}
+        onSuccess={() => {
+          setShowAdminModal(false);
+          handleSave(); // Retry saving with the new session
+        }}
+      />
+    </div>
+  );
+}

--- a/app/signups/page.tsx
+++ b/app/signups/page.tsx
@@ -25,10 +25,6 @@ interface Settings {
   availableDays: string[];
 }
 
-const DAY_MAP: Record<string, Day> = {
-  "Sunday": 0, "Monday": 1, "Tuesday": 2, "Wednesday": 3, "Thursday": 4, "Friday": 5, "Saturday": 6
-};
-
 export default function SignupsPage() {
   const [settings, setSettings] = useState<Settings | null>(null);
   const [now, setNow] = useState<Date | null>(null);
@@ -71,11 +67,11 @@ export default function SignupsPage() {
     const dates: string[] = [];
     
     // 1. Current Week (Sun to Sat)
-    let currentWeekStart = new Date(now);
+    const currentWeekStart = new Date(now);
     currentWeekStart.setDate(now.getDate() - now.getDay()); // Sunday
     
     // 2. Next Week (Sun to Sat)
-    let nextWeekStart = new Date(currentWeekStart);
+    const nextWeekStart = new Date(currentWeekStart);
     nextWeekStart.setDate(currentWeekStart.getDate() + 7);
     
     const generateWeekDates = (weekStart: Date) => {
@@ -192,7 +188,7 @@ export default function SignupsPage() {
   const nextOpenDate = settings ? (() => {
     const baseNow = new Date();
     const [hours, minutes] = settings.signupOpenTime.split(':').map(Number);
-    let openDateTime = new Date();
+    const openDateTime = new Date();
     openDateTime.setHours(hours, minutes, 0, 0);
 
     let daysUntilOpen = (settings.signupOpenDayOfWeek - openDateTime.getDay() + 7) % 7;
@@ -214,7 +210,7 @@ export default function SignupsPage() {
     <div className="max-w-4xl mx-auto p-6 space-y-8">
       {isCountdownActive && nextOpenDate && (
         <div className="bg-blue-50 border border-blue-200 rounded-lg p-5 flex flex-col items-center justify-center text-blue-800 shadow-sm">
-            <h2 className="text-sm font-semibold uppercase tracking-wide text-blue-600 mb-2 mt-1">Next Week's Signups Open In</h2>
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-blue-600 mb-2 mt-1">Next Week&apos;s Signups Open In</h2>
             <div className="text-4xl font-mono font-bold tabular-nums mb-2">
                 {days > 0 && `${days}d `}
                 {hours.toString().padStart(2, '0')}:{minutes.toString().padStart(2, '0')}:{seconds.toString().padStart(2, '0')}

--- a/app/signups/page.tsx
+++ b/app/signups/page.tsx
@@ -1,0 +1,368 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { format, addDays, Day } from 'date-fns';
+import { AdminLoginModal } from '../components/AdminLoginModal';
+import { Trash2, Plus, Clock } from 'lucide-react';
+
+interface Player {
+  id: number;
+  name: string;
+}
+
+interface Signup {
+  id: number;
+  player_id: number;
+  name: string;
+  date: string;
+  status: 'registered' | 'waitlisted';
+  created_at: string;
+}
+
+interface Settings {
+  signupOpenDayOfWeek: number;
+  signupOpenTime: string;
+  availableDays: string[];
+}
+
+const DAY_MAP: Record<string, Day> = {
+  "Sunday": 0, "Monday": 1, "Tuesday": 2, "Wednesday": 3, "Thursday": 4, "Friday": 5, "Saturday": 6
+};
+
+export default function SignupsPage() {
+  const [settings, setSettings] = useState<Settings | null>(null);
+  const [now, setNow] = useState<Date | null>(null);
+  const [players, setPlayers] = useState<Player[]>([]);
+  const [signups, setSignups] = useState<Signup[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  
+  const [selectedPlayerId, setSelectedPlayerId] = useState<string>('');
+  const [showAdminModal, setShowAdminModal] = useState(false);
+  const [actionPending, setActionPending] = useState<(() => Promise<void>) | null>(null);
+
+  useEffect(() => {
+    setNow(new Date());
+    const interval = setInterval(() => setNow(new Date()), 1000);
+    fetchData();
+    return () => clearInterval(interval);
+  }, []);
+
+  const fetchData = async () => {
+    try {
+      const [settingsRes, playersRes, signupsRes] = await Promise.all([
+        fetch('/api/settings'),
+        fetch('/api/players'),
+        fetch('/api/signups')
+      ]);
+
+      if (settingsRes.ok) setSettings(await settingsRes.json());
+      if (playersRes.ok) setPlayers(await playersRes.json());
+      if (signupsRes.ok) setSignups(await signupsRes.json());
+    } catch (error) {
+      console.error('Failed to load data:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const getUpcomingDates = () => {
+    if (!settings || !settings.availableDays.length || !now) return [];
+    
+    const dates: string[] = [];
+    
+    // 1. Current Week (Sun to Sat)
+    let currentWeekStart = new Date(now);
+    currentWeekStart.setDate(now.getDate() - now.getDay()); // Sunday
+    
+    // 2. Next Week (Sun to Sat)
+    let nextWeekStart = new Date(currentWeekStart);
+    nextWeekStart.setDate(currentWeekStart.getDate() + 7);
+    
+    const generateWeekDates = (weekStart: Date) => {
+        const weekDates: string[] = [];
+        let d = new Date(weekStart);
+        for (let i = 0; i < 7; i++) {
+            const dayName = format(d, 'EEEE');
+            if (settings.availableDays.includes(dayName)) {
+                weekDates.push(format(d, 'yyyy-MM-dd'));
+            }
+            d = addDays(d, 1);
+        }
+        return weekDates;
+    };
+    
+    const currentWeekDates = generateWeekDates(currentWeekStart);
+    const nextWeekDates = generateWeekDates(nextWeekStart);
+    
+    // Tomorrow (since we move "today" to previous week)
+    const tomorrowStr = format(addDays(new Date(), 1), 'yyyy-MM-dd');
+    
+    // Add current week dates that are >= tomorrow
+    currentWeekDates.forEach(dateStr => {
+        if (dateStr >= tomorrowStr) {
+            dates.push(dateStr);
+        }
+    });
+    
+    // For next week, check if it has opened
+    const [hours, minutes] = settings.signupOpenTime.split(':').map(Number);
+    const openDateTime = new Date(currentWeekStart);
+    openDateTime.setDate(currentWeekStart.getDate() + settings.signupOpenDayOfWeek);
+    openDateTime.setHours(hours, minutes, 0, 0);
+    
+    if (now >= openDateTime) {
+        nextWeekDates.forEach(dateStr => {
+            dates.push(dateStr);
+        });
+    }
+    
+    return dates.sort();
+  };
+
+  const handleSignup = async (date: string) => {
+    if (!selectedPlayerId) return alert('Please select a player first');
+
+    const doSignup = async () => {
+      const res = await fetch('/api/signups', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ playerId: parseInt(selectedPlayerId), date })
+      });
+
+      if (res.status === 401 || res.status === 403) {
+        // Might need admin to bypass time restrictions or edit
+        setActionPending(() => doSignup);
+        setShowAdminModal(true);
+        return;
+      }
+
+      if (res.ok) {
+        await fetchData(); // Refresh data
+      } else {
+        const data = await res.json();
+        alert(data.error || 'Failed to sign up');
+      }
+    };
+
+    await doSignup();
+  };
+
+  const handleDelete = async (signupId: number) => {
+    if (!confirm('Are you sure you want to remove this player?')) return;
+
+    const doDelete = async () => {
+      const res = await fetch('/api/signups', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: signupId })
+      });
+
+      if (res.status === 401) {
+        setActionPending(() => doDelete);
+        setShowAdminModal(true);
+        return;
+      }
+
+      if (res.ok) {
+        await fetchData();
+      } else {
+        const data = await res.json();
+        alert(data.error || 'Failed to remove player');
+      }
+    };
+
+    await doDelete();
+  };
+
+  const executePendingAction = async () => {
+    setShowAdminModal(false);
+    if (actionPending) {
+        await actionPending();
+        setActionPending(null);
+    }
+  };
+
+  if (isLoading) return <div className="p-8 text-center text-gray-500">Loading signups...</div>;
+
+  const upcomingDates = getUpcomingDates();
+  const previousDates = Array.from(new Set(signups.map(s => s.date)))
+    .filter(d => !upcomingDates.includes(d))
+    .sort();
+
+  const nextOpenDate = settings ? (() => {
+    const baseNow = new Date();
+    const [hours, minutes] = settings.signupOpenTime.split(':').map(Number);
+    let openDateTime = new Date();
+    openDateTime.setHours(hours, minutes, 0, 0);
+
+    let daysUntilOpen = (settings.signupOpenDayOfWeek - openDateTime.getDay() + 7) % 7;
+    if (daysUntilOpen === 0 && baseNow > openDateTime) {
+       daysUntilOpen = 7;
+    }
+    openDateTime.setDate(openDateTime.getDate() + daysUntilOpen);
+    return openDateTime;
+  })() : null;
+
+  const timeDiffMs = nextOpenDate && now ? nextOpenDate.getTime() - now.getTime() : 0;
+  const isCountdownActive = timeDiffMs > 0;
+  const days = Math.floor(timeDiffMs / (1000 * 60 * 60 * 24));
+  const hours = Math.floor((timeDiffMs / (1000 * 60 * 60)) % 24);
+  const minutes = Math.floor((timeDiffMs / 1000 / 60) % 60);
+  const seconds = Math.floor((timeDiffMs / 1000) % 60);
+
+  return (
+    <div className="max-w-4xl mx-auto p-6 space-y-8">
+      {isCountdownActive && nextOpenDate && (
+        <div className="bg-blue-50 border border-blue-200 rounded-lg p-5 flex flex-col items-center justify-center text-blue-800 shadow-sm">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-blue-600 mb-2 mt-1">Next Week's Signups Open In</h2>
+            <div className="text-4xl font-mono font-bold tabular-nums mb-2">
+                {days > 0 && `${days}d `}
+                {hours.toString().padStart(2, '0')}:{minutes.toString().padStart(2, '0')}:{seconds.toString().padStart(2, '0')}
+            </div>
+            <p className="text-sm text-blue-500 font-medium mb-1">
+                {format(nextOpenDate, 'EEEE, MMMM do')} at {format(nextOpenDate, 'h:mm a')}
+            </p>
+        </div>
+      )}
+
+      <div className="border-b border-gray-200 pb-4 flex justify-between items-end">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-800">Weekly Signups</h1>
+          <p className="text-gray-500 mt-1">Opt in to play for the upcoming week. Max 6 players per day.</p>
+        </div>
+        
+        <div className="flex items-center gap-2">
+           <select 
+             value={selectedPlayerId}
+             onChange={(e) => setSelectedPlayerId(e.target.value)}
+             className="p-2 border rounded-md focus:ring-2 focus:ring-blue-500 w-48"
+           >
+             <option value="">-- Who are you? --</option>
+             {[...players].sort((a, b) => a.name.localeCompare(b.name)).map(p => (
+                 <option key={p.id} value={p.id}>{p.name}</option>
+             ))}
+           </select>
+        </div>
+      </div>
+
+      <div className="space-y-6">
+        {upcomingDates.length === 0 ? (
+            <div className="text-center text-gray-500 py-8 bg-white rounded-lg border border-gray-200">
+                {(!settings || settings.availableDays.length === 0) 
+                  ? "No available playing days configured. Ask an admin to check settings."
+                  : "Signups are not currently open for any upcoming days."
+                }
+            </div>
+        ) : (
+            upcomingDates.map(dateStr => {
+                const daySignups = signups.filter(s => s.date === dateStr);
+                const registered = daySignups.filter(s => s.status === 'registered');
+                const waitlisted = daySignups.filter(s => s.status === 'waitlisted');
+                const isFull = registered.length >= 6;
+                const dateObj = new Date(dateStr + "T12:00:00");
+
+                return (
+                    <div key={dateStr} className="bg-white rounded-lg border border-gray-200 overflow-hidden shadow-sm">
+                        <div className="bg-gray-50 p-4 border-b border-gray-200 flex justify-between items-center">
+                            <div>
+                                <h2 className="text-lg font-bold text-gray-800">{format(dateObj, 'EEEE, MMMM do')}</h2>
+                                <p className="text-sm text-gray-500">{registered.length}/6 spots filled</p>
+                            </div>
+                            <button
+                                onClick={() => handleSignup(dateStr)}
+                                className={`flex items-center gap-1 px-4 py-2 rounded-md font-medium transition-colors
+                                  ${isFull 
+                                    ? 'bg-orange-100 text-orange-700 hover:bg-orange-200' 
+                                    : 'bg-blue-600 text-white hover:bg-blue-700'}`}
+                            >
+                                <Plus className="w-4 h-4" />
+                                {isFull ? 'Join Waitlist' : 'Sign Up'}
+                            </button>
+                        </div>
+                        
+                        <div className="p-0">
+                            {registered.length === 0 ? (
+                                <div className="p-4 text-center text-gray-400 italic">No one signed up yet</div>
+                            ) : (
+                                <ul className="divide-y divide-gray-100">
+                                    {registered.map((signup, idx) => (
+                                        <li key={signup.id} className="flex justify-between items-center p-3 hover:bg-gray-50 transition-colors">
+                                            <div className="flex items-center gap-3">
+                                                <span className="text-gray-400 font-mono w-4">{idx + 1}.</span>
+                                                <span className="font-medium text-gray-800">{signup.name}</span>
+                                            </div>
+                                            <button 
+                                                onClick={() => handleDelete(signup.id)}
+                                                className="text-red-400 hover:text-red-600 p-2 rounded-md hover:bg-red-50"
+                                                title="Remove player"
+                                            >
+                                                <Trash2 className="w-4 h-4" />
+                                            </button>
+                                        </li>
+                                    ))}
+                                </ul>
+                            )}
+                        </div>
+
+                        {waitlisted.length > 0 && (
+                            <div className="bg-orange-50/50 p-3 border-t border-orange-100">
+                                <h3 className="text-xs font-semibold uppercase text-orange-800 mb-2 flex items-center gap-1">
+                                    <Clock className="w-3 h-3" /> Waitlist
+                                </h3>
+                                <ul className="space-y-1">
+                                    {waitlisted.map((signup, idx) => (
+                                        <li key={signup.id} className="flex justify-between items-center text-sm text-gray-600 pl-2">
+                                            <span>{idx + 1}. {signup.name}</span>
+                                            <button 
+                                                onClick={() => handleDelete(signup.id)}
+                                                className="text-orange-400 hover:text-orange-600 p-1 rounded hover:bg-orange-100"
+                                            >
+                                                <Trash2 className="w-3 h-3" />
+                                            </button>
+                                        </li>
+                                    ))}
+                                </ul>
+                            </div>
+                        )}
+                    </div>
+                );
+            })
+        )}
+      </div>
+
+      {previousDates.length > 0 && (
+          <div className="pt-8 mt-8 border-t border-gray-200">
+              <h2 className="text-xl font-bold text-gray-700 mb-6">Previous Week</h2>
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                  {previousDates.map(dateStr => {
+                      const daySignups = signups.filter(s => s.date === dateStr && s.status === 'registered');
+                      if (daySignups.length === 0) return null;
+                      
+                      const dateObj = new Date(dateStr + "T12:00:00");
+                      
+                      return (
+                          <div key={dateStr} className="bg-gray-50 rounded-lg border border-gray-200 p-4 opacity-80">
+                              <h3 className="font-semibold text-gray-800 mb-3">{format(dateObj, 'EEEE, MMM do')}</h3>
+                              <ul className="space-y-1">
+                                  {daySignups.map((s, idx) => (
+                                      <li key={s.id} className="text-sm text-gray-600 flex items-center">
+                                          <span className="text-gray-400 font-mono w-4 mr-2">{idx + 1}.</span>
+                                          {s.name}
+                                      </li>
+                                  ))}
+                              </ul>
+                          </div>
+                      );
+                  })}
+              </div>
+          </div>
+      )}
+
+      <AdminLoginModal
+        isOpen={showAdminModal}
+        onClose={() => setShowAdminModal(false)}
+        onSuccess={executePendingAction}
+      />
+    </div>
+  );
+}

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, serial, integer, timestamp, index, boolean } from "drizzle-orm/pg-core";
+import { pgTable, text, serial, integer, timestamp, index } from "drizzle-orm/pg-core";
 import { createInsertSchema, createSelectSchema } from "drizzle-zod";
 
 export const players = pgTable("players", {

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -63,6 +63,27 @@ export const dailySummaries = pgTable("daily_summaries", {
   dateIdx: index("daily_summary_date_idx").on(table.date),
 }));
 
+// Site settings
+export const siteSettings = pgTable("site_settings", {
+  id: serial("id").primaryKey(),
+  adminPasswordHash: text("admin_password_hash"),
+  signupOpenDayOfWeek: integer("signup_open_day_of_week").default(0), // 0 = Sunday
+  signupOpenTime: text("signup_open_time").default("12:00"), // HH:mm
+  availableDays: text("available_days").default(JSON.stringify(["Monday", "Tuesday", "Thursday"])),
+});
+
+// Weekly signups
+export const weeklySignups = pgTable("weekly_signups", {
+  id: serial("id").primaryKey(),
+  playerId: integer("player_id").references(() => players.id).notNull(),
+  date: text("date").notNull(), // YYYY-MM-DD
+  status: text("status").notNull().default("registered"), // "registered" or "waitlisted"
+  createdAt: timestamp("created_at").defaultNow(),
+}, (table) => ({
+  dateIdx: index("weekly_signup_date_idx").on(table.date),
+  playerDateIdx: index("weekly_signup_player_date_idx").on(table.playerId, table.date),
+}));
+
 export const insertPlayerSchema = createInsertSchema(players);
 export const selectPlayerSchema = createSelectSchema(players);
 export const insertMatchSchema = createInsertSchema(matches);
@@ -75,6 +96,12 @@ export const selectPlayerAchievementSchema = createSelectSchema(playerAchievemen
 export const insertDailySummarySchema = createInsertSchema(dailySummaries);
 export const selectDailySummarySchema = createSelectSchema(dailySummaries);
 
+export const insertSiteSettingSchema = createInsertSchema(siteSettings);
+export const selectSiteSettingSchema = createSelectSchema(siteSettings);
+
+export const insertWeeklySignupSchema = createInsertSchema(weeklySignups);
+export const selectWeeklySignupSchema = createSelectSchema(weeklySignups);
+
 export type Player = typeof players.$inferSelect;
 export type NewPlayer = typeof players.$inferInsert;
 export type Match = typeof matches.$inferSelect;
@@ -86,3 +113,9 @@ export type NewPlayerAchievement = typeof playerAchievements.$inferInsert;
 
 export type DailySummary = typeof dailySummaries.$inferSelect;
 export type NewDailySummary = typeof dailySummaries.$inferInsert;
+
+export type SiteSetting = typeof siteSettings.$inferSelect;
+export type NewSiteSetting = typeof siteSettings.$inferInsert;
+
+export type WeeklySignup = typeof weeklySignups.$inferSelect;
+export type NewWeeklySignup = typeof weeklySignups.$inferInsert;

--- a/migrations/007_add_signups.sql
+++ b/migrations/007_add_signups.sql
@@ -1,0 +1,25 @@
+CREATE TABLE IF NOT EXISTS "site_settings" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"admin_password_hash" text,
+	"signup_open_day_of_week" integer DEFAULT 0,
+	"signup_open_time" text DEFAULT '12:00',
+	"available_days" text DEFAULT '["Monday","Tuesday","Thursday"]'
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "weekly_signups" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"player_id" integer NOT NULL,
+	"date" text NOT NULL,
+	"status" text DEFAULT 'registered' NOT NULL,
+	"created_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "weekly_signups" ADD CONSTRAINT "weekly_signups_player_id_players_id_fk" FOREIGN KEY ("player_id") REFERENCES "public"."players"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "weekly_signup_date_idx" ON "weekly_signups" ("date");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "weekly_signup_player_date_idx" ON "weekly_signups" ("player_id","date");


### PR DESCRIPTION
Introduces a weekly signup system allowing players to opt into available play days with a 6-player capacity limit and waitlist support.

## Key Changes
- **New Tables**: `site_settings` and `weekly_signups`
- **Admin Configuration**: Secure UI to set open times and available days.
- **Signup Page**: Countdown timer to weekly open time, player selection, and capacity/waitlist handling.
- **Code Cleanups**: Fixed unused imports, explicitly typed API payload, and removed stale comments.