### PR TITLE
Update signup cycle close window and countdowns

### DIFF
--- a/__tests__/api/signups.test.ts
+++ b/__tests__/api/signups.test.ts
@@ -1,0 +1,121 @@
+import { POST } from '@/app/api/signups/route';
+
+const mockSql = jest.fn();
+const mockCookies = {
+  get: jest.fn(),
+};
+
+const createMockSql = () => Object.assign(
+  jest.fn().mockImplementation((strings: TemplateStringsArray) => {
+    const query = strings.join(' ');
+
+    if (query.includes('SELECT signup_open_day_of_week')) {
+      return mockSql('settings');
+    }
+
+    if (query.includes('SELECT id FROM weekly_signups WHERE player_id')) {
+      return mockSql('existing-signup');
+    }
+
+    if (query.includes("SELECT count(*) as total FROM weekly_signups WHERE date")) {
+      return mockSql('signup-count');
+    }
+
+    if (query.includes('INSERT INTO weekly_signups')) {
+      return mockSql('insert-signup');
+    }
+
+    return mockSql('unknown');
+  }),
+  {
+    transaction: jest.fn(),
+  }
+);
+
+jest.mock('@neondatabase/serverless', () => ({
+  neon: jest.fn(() => createMockSql()),
+}));
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn(() => mockCookies),
+}));
+
+process.env.DATABASE_URL = 'mock-database-url';
+
+describe('/api/signups POST', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useRealTimers();
+    mockCookies.get.mockReturnValue(undefined);
+  });
+
+  it('rejects non-admin signups after the close cutoff', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-01-12T00:30:00.000Z'));
+
+    mockSql.mockImplementation((queryType) => {
+      if (queryType === 'settings') {
+        return Promise.resolve([{
+          signup_open_day_of_week: 0,
+          signup_open_time: '12:00',
+          signup_close_day_of_week: 0,
+          signup_close_time: '16:00',
+          available_days: '["Monday","Tuesday","Thursday"]',
+        }]);
+      }
+
+      return Promise.resolve([]);
+    });
+
+    const response = await POST({
+      json: async () => ({ playerId: 1, date: '2026-01-19' }),
+    } as Request);
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data).toEqual({ error: 'Signups are closed for this date' });
+    expect(mockSql).toHaveBeenCalledWith('settings');
+    expect(mockSql).not.toHaveBeenCalledWith('insert-signup');
+  });
+
+  it('accepts non-admin signups during the active window for configured days', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-01-11T18:30:00.000Z'));
+
+    mockSql.mockImplementation((queryType) => {
+      if (queryType === 'settings') {
+        return Promise.resolve([{
+          signup_open_day_of_week: 0,
+          signup_open_time: '12:00',
+          signup_close_day_of_week: 0,
+          signup_close_time: '16:00',
+          available_days: '["Monday","Tuesday","Thursday"]',
+        }]);
+      }
+
+      if (queryType === 'existing-signup') {
+        return Promise.resolve([]);
+      }
+
+      if (queryType === 'signup-count') {
+        return Promise.resolve([{ total: '2' }]);
+      }
+
+      if (queryType === 'insert-signup') {
+        return Promise.resolve([{ id: 99, player_id: 1, date: '2026-01-19', status: 'registered' }]);
+      }
+
+      return Promise.resolve([]);
+    });
+
+    const response = await POST({
+      json: async () => ({ playerId: 1, date: '2026-01-19' }),
+    } as Request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({
+      success: true,
+      signup: { id: 99, player_id: 1, date: '2026-01-19', status: 'registered' },
+    });
+    expect(mockSql).toHaveBeenCalledWith('insert-signup');
+  });
+});

--- a/agent-context/data-model.json
+++ b/agent-context/data-model.json
@@ -265,6 +265,18 @@
           "references": null
         },
         {
+          "field": "signupCloseDayOfWeek",
+          "kind": "integer",
+          "column": "signup_close_day_of_week",
+          "references": null
+        },
+        {
+          "field": "signupCloseTime",
+          "kind": "text",
+          "column": "signup_close_time",
+          "references": null
+        },
+        {
           "field": "availableDays",
           "kind": "text",
           "column": "available_days",
@@ -274,7 +286,8 @@
       "selectType": "SiteSetting",
       "insertType": "NewSiteSetting",
       "migrationTouchpoints": [
-        "migrations/007_add_signups.sql"
+        "migrations/007_add_signups.sql",
+        "migrations/008_add_signup_close_settings.sql"
       ]
     },
     {

--- a/agent-context/graph.json
+++ b/agent-context/graph.json
@@ -294,9 +294,16 @@
       "file": "app/api/signups/route.ts",
       "type": "api-route",
       "tags": [],
-      "imports": [],
-      "importedBy": [],
-      "related": [],
+      "imports": [
+        "app/lib/signups.ts"
+      ],
+      "importedBy": [
+        "__tests__/api/signups.test.ts"
+      ],
+      "related": [
+        "__tests__/api/signups.test.ts",
+        "app/lib/signups.ts"
+      ],
       "overrideNotes": []
     },
     {
@@ -744,6 +751,19 @@
       "overrideNotes": []
     },
     {
+      "file": "app/lib/__tests__/signups.test.ts",
+      "type": "app-lib",
+      "tags": [],
+      "imports": [
+        "app/lib/signups.ts"
+      ],
+      "importedBy": [],
+      "related": [
+        "app/lib/signups.ts"
+      ],
+      "overrideNotes": []
+    },
+    {
       "file": "app/lib/__tests__/tooltip.test.ts",
       "type": "app-lib",
       "tags": [],
@@ -850,6 +870,23 @@
       ],
       "related": [
         "app/lib/openai.ts"
+      ],
+      "overrideNotes": []
+    },
+    {
+      "file": "app/lib/signups.ts",
+      "type": "app-lib",
+      "tags": [],
+      "imports": [],
+      "importedBy": [
+        "app/api/signups/route.ts",
+        "app/lib/__tests__/signups.test.ts",
+        "app/signups/page.tsx"
+      ],
+      "related": [
+        "app/api/signups/route.ts",
+        "app/lib/__tests__/signups.test.ts",
+        "app/signups/page.tsx"
       ],
       "overrideNotes": []
     },
@@ -1024,11 +1061,13 @@
       "type": "page",
       "tags": [],
       "imports": [
-        "app/components/AdminLoginModal.tsx"
+        "app/components/AdminLoginModal.tsx",
+        "app/lib/signups.ts"
       ],
       "importedBy": [],
       "related": [
-        "app/components/AdminLoginModal.tsx"
+        "app/components/AdminLoginModal.tsx",
+        "app/lib/signups.ts"
       ],
       "overrideNotes": []
     },

--- a/agent-context/routes.json
+++ b/agent-context/routes.json
@@ -188,7 +188,9 @@
       "route": "/api/signups",
       "file": "app/api/signups/route.ts",
       "params": [],
-      "likelySourceFiles": []
+      "likelySourceFiles": [
+        "app/lib/signups.ts"
+      ]
     },
     {
       "kind": "api",
@@ -256,7 +258,8 @@
       "file": "app/signups/page.tsx",
       "params": [],
       "likelySourceFiles": [
-        "app/components/AdminLoginModal.tsx"
+        "app/components/AdminLoginModal.tsx",
+        "app/lib/signups.ts"
       ]
     }
   ]

--- a/agent-context/tests.json
+++ b/agent-context/tests.json
@@ -39,6 +39,13 @@
       ]
     },
     {
+      "path": "__tests__/api/signups.test.ts",
+      "kind": "test",
+      "covers": [
+        "app/api/signups/route.ts"
+      ]
+    },
+    {
       "path": "__tests__/api/team-performance.test.ts",
       "kind": "test",
       "covers": [
@@ -57,6 +64,13 @@
       "kind": "component",
       "covers": [
         "app/components/PerformanceControls.tsx"
+      ]
+    },
+    {
+      "path": "app/lib/__tests__/signups.test.ts",
+      "kind": "app-lib",
+      "covers": [
+        "app/lib/signups.ts"
       ]
     },
     {
@@ -84,6 +98,9 @@
     "app/api/seasons/route.ts": [
       "__tests__/api/seasons.test.ts"
     ],
+    "app/api/signups/route.ts": [
+      "__tests__/api/signups.test.ts"
+    ],
     "app/api/team-performance/route.ts": [
       "__tests__/api/team-performance.test.ts"
     ],
@@ -92,6 +109,9 @@
     ],
     "app/components/SeasonSelector.tsx": [
       "__tests__/components/SeasonSelector.test.tsx"
+    ],
+    "app/lib/signups.ts": [
+      "app/lib/__tests__/signups.test.ts"
     ],
     "app/lib/tooltip.ts": [
       "app/lib/__tests__/tooltip.test.ts"

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -17,6 +17,8 @@ export async function GET() {
       return NextResponse.json({
         signupOpenDayOfWeek: settings[0].signup_open_day_of_week,
         signupOpenTime: settings[0].signup_open_time,
+        signupCloseDayOfWeek: settings[0].signup_close_day_of_week ?? 0,
+        signupCloseTime: settings[0].signup_close_time ?? '16:00',
         availableDays: JSON.parse(settings[0].available_days || '["Monday", "Tuesday", "Thursday"]')
       });
     }
@@ -25,6 +27,8 @@ export async function GET() {
     return NextResponse.json({
       signupOpenDayOfWeek: 0, // Sunday
       signupOpenTime: '12:00', // Noon
+      signupCloseDayOfWeek: 0, // Sunday
+      signupCloseTime: '16:00', // 4 PM
       availableDays: ["Monday", "Tuesday", "Thursday"]
     });
   } catch (error) {
@@ -62,16 +66,20 @@ export async function PUT(request: Request) {
         SET 
           signup_open_day_of_week = COALESCE(${body.signupOpenDayOfWeek}, signup_open_day_of_week),
           signup_open_time = COALESCE(${body.signupOpenTime}, signup_open_time),
+          signup_close_day_of_week = COALESCE(${body.signupCloseDayOfWeek}, signup_close_day_of_week),
+          signup_close_time = COALESCE(${body.signupCloseTime}, signup_close_time),
           available_days = COALESCE(${JSON.stringify(body.availableDays)}, available_days),
           admin_password_hash = COALESCE(${body.adminPassword}, admin_password_hash)
         WHERE id = ${existing[0].id}
       `;
     } else {
       await sql`
-        INSERT INTO site_settings (signup_open_day_of_week, signup_open_time, available_days, admin_password_hash)
+        INSERT INTO site_settings (signup_open_day_of_week, signup_open_time, signup_close_day_of_week, signup_close_time, available_days, admin_password_hash)
         VALUES (
           ${body.signupOpenDayOfWeek ?? 0}, 
           ${body.signupOpenTime || '12:00'}, 
+          ${body.signupCloseDayOfWeek ?? 0},
+          ${body.signupCloseTime || '16:00'},
           ${JSON.stringify(body.availableDays || ["Monday", "Tuesday", "Thursday"])},
           ${body.adminPassword || 'admin'}
         )

--- a/app/api/signups/route.ts
+++ b/app/api/signups/route.ts
@@ -1,26 +1,12 @@
 import { NextResponse } from 'next/server';
 import { neon } from '@neondatabase/serverless';
 import { cookies } from 'next/headers';
-
-function getEstNow() {
-  return new Date(new Date().toLocaleString("en-US", {timeZone: "America/New_York"}));
-}
-
-function isSignupOpen(targetDateStr: string, openDayOfWeek: number, openTime: string) {
-  const targetDate = new Date(`${targetDateStr}T12:00:00-05:00`); // using roughly EST offset for date math
-  const [hours, minutes] = openTime.split(':').map(Number);
-  
-  // Find the Sunday that starts this target date's calendar week
-  const weekStartSunday = new Date(targetDate);
-  weekStartSunday.setDate(targetDate.getDate() - targetDate.getDay());
-  
-  // The signups for this calendar week open on the openDayOfWeek of the PRECEDING week
-  const openDateTime = new Date(weekStartSunday);
-  openDateTime.setDate(weekStartSunday.getDate() - 7 + openDayOfWeek);
-  openDateTime.setHours(hours, minutes, 0, 0);
-  
-  return getEstNow() >= openDateTime;
-}
+import {
+  getEasternWallTimeNow,
+  getSignupCycleState,
+  isDateInSignupWeek,
+  type SignupSettings,
+} from '../../lib/signups';
 
 export async function GET(request: Request) {
   try {
@@ -78,13 +64,33 @@ export async function POST(request: Request) {
     const sql = neon(process.env.DATABASE_URL);
 
     // Check if open
-    const settings = await sql`SELECT signup_open_day_of_week, signup_open_time FROM site_settings LIMIT 1`;
+    const settings = await sql`
+      SELECT signup_open_day_of_week, signup_open_time, signup_close_day_of_week, signup_close_time, available_days
+      FROM site_settings
+      LIMIT 1
+    `;
     const isAdmin = cookies().get('admin_token')?.value === 'true';
     
-    if (settings.length > 0 && !isAdmin) {
-      const { signup_open_day_of_week, signup_open_time } = settings[0];
-      if (!isSignupOpen(date, signup_open_day_of_week, signup_open_time)) {
-        return NextResponse.json({ error: 'Signups are not open yet for this date' }, { status: 403 });
+    if (!isAdmin) {
+      const signupSettings: SignupSettings = settings.length > 0
+        ? {
+            signupOpenDayOfWeek: settings[0].signup_open_day_of_week ?? 0,
+            signupOpenTime: settings[0].signup_open_time ?? '12:00',
+            signupCloseDayOfWeek: settings[0].signup_close_day_of_week ?? 0,
+            signupCloseTime: settings[0].signup_close_time ?? '16:00',
+            availableDays: JSON.parse(settings[0].available_days || '["Monday","Tuesday","Thursday"]'),
+          }
+        : {
+            signupOpenDayOfWeek: 0,
+            signupOpenTime: '12:00',
+            signupCloseDayOfWeek: 0,
+            signupCloseTime: '16:00',
+            availableDays: ['Monday', 'Tuesday', 'Thursday'],
+          };
+
+      const signupState = getSignupCycleState(getEasternWallTimeNow(), signupSettings);
+      if (!signupState.isOpen || !isDateInSignupWeek(date, signupState.signupWeekSunday, signupSettings.availableDays)) {
+        return NextResponse.json({ error: 'Signups are closed for this date' }, { status: 403 });
       }
     }
 

--- a/app/lib/__tests__/signups.test.ts
+++ b/app/lib/__tests__/signups.test.ts
@@ -1,0 +1,53 @@
+import { format } from 'date-fns';
+import {
+  generateWeekDates,
+  getSignupCycleState,
+  isDateInSignupWeek,
+  type SignupSettings,
+} from '../signups';
+
+const defaultSettings: SignupSettings = {
+  signupOpenDayOfWeek: 0,
+  signupOpenTime: '12:00',
+  signupCloseDayOfWeek: 0,
+  signupCloseTime: '16:00',
+  availableDays: ['Monday', 'Tuesday', 'Thursday'],
+};
+
+describe('signup cycle utilities', () => {
+  it('stays closed before the configured open time', () => {
+    const state = getSignupCycleState(new Date(2026, 0, 11, 11, 0, 0), defaultSettings);
+
+    expect(state.isOpen).toBe(false);
+    expect(format(state.currentWeekSunday, 'yyyy-MM-dd')).toBe('2026-01-11');
+    expect(format(state.nextOpenDateTime, 'yyyy-MM-dd HH:mm')).toBe('2026-01-11 12:00');
+  });
+
+  it('opens only inside the configured same-day signup window', () => {
+    const state = getSignupCycleState(new Date(2026, 0, 11, 13, 0, 0), defaultSettings);
+
+    expect(state.isOpen).toBe(true);
+    expect(format(state.signupWeekSunday!, 'yyyy-MM-dd')).toBe('2026-01-18');
+    expect(format(state.currentWeekSunday, 'yyyy-MM-dd')).toBe('2026-01-11');
+  });
+
+  it('returns to closed after the close cutoff and advances the countdown', () => {
+    const state = getSignupCycleState(new Date(2026, 0, 12, 9, 0, 0), defaultSettings);
+
+    expect(state.isOpen).toBe(false);
+    expect(format(state.currentWeekSunday, 'yyyy-MM-dd')).toBe('2026-01-18');
+    expect(format(state.nextOpenDateTime, 'yyyy-MM-dd HH:mm')).toBe('2026-01-18 12:00');
+  });
+
+  it('matches dates against the active signup week', () => {
+    const signupWeekSunday = new Date(2026, 0, 18, 0, 0, 0);
+
+    expect(generateWeekDates(signupWeekSunday, defaultSettings.availableDays)).toEqual([
+      '2026-01-19',
+      '2026-01-20',
+      '2026-01-22',
+    ]);
+    expect(isDateInSignupWeek('2026-01-19', signupWeekSunday, defaultSettings.availableDays)).toBe(true);
+    expect(isDateInSignupWeek('2026-01-21', signupWeekSunday, defaultSettings.availableDays)).toBe(false);
+  });
+});

--- a/app/lib/signups.ts
+++ b/app/lib/signups.ts
@@ -1,0 +1,134 @@
+import { addDays, format } from 'date-fns';
+
+export interface SignupSettings {
+  signupOpenDayOfWeek: number;
+  signupOpenTime: string;
+  signupCloseDayOfWeek: number;
+  signupCloseTime: string;
+  availableDays: string[];
+}
+
+interface SignupWindow {
+  weekSunday: Date;
+  openDateTime: Date;
+  closeDateTime: Date;
+}
+
+export interface SignupCycleState {
+  isOpen: boolean;
+  signupWeekSunday: Date | null;
+  currentWeekSunday: Date;
+  nextOpenDateTime: Date;
+  openDateTime: Date | null;
+  closeDateTime: Date;
+}
+
+export function getEasternWallTimeNow(reference: Date = new Date()): Date {
+  return new Date(reference.toLocaleString('en-US', { timeZone: 'America/New_York' }));
+}
+
+export function generateWeekDates(weekSunday: Date, availableDays: string[]): string[] {
+  const dates: string[] = [];
+  for (let i = 0; i < 7; i += 1) {
+    const date = addDays(weekSunday, i);
+    if (availableDays.includes(format(date, 'EEEE'))) {
+      dates.push(format(date, 'yyyy-MM-dd'));
+    }
+  }
+  return dates;
+}
+
+export function getSunday(date: Date): Date {
+  const sunday = new Date(date);
+  sunday.setDate(date.getDate() - date.getDay());
+  sunday.setHours(0, 0, 0, 0);
+  return sunday;
+}
+
+export function parseTime(time: string): { hours: number; minutes: number } {
+  const [rawHours = '0', rawMinutes = '0'] = time.split(':');
+  const hours = Number(rawHours);
+  const minutes = Number(rawMinutes);
+
+  return {
+    hours: Number.isFinite(hours) ? hours : 0,
+    minutes: Number.isFinite(minutes) ? minutes : 0,
+  };
+}
+
+function getDateTimeInWeek(weekSunday: Date, dayOfWeek: number, time: string): Date {
+  const target = addDays(weekSunday, dayOfWeek);
+  const { hours, minutes } = parseTime(time);
+  target.setHours(hours, minutes, 0, 0);
+  return target;
+}
+
+function getSignupWindow(weekSunday: Date, settings: SignupSettings): SignupWindow {
+  const openDateTime = getDateTimeInWeek(weekSunday, settings.signupOpenDayOfWeek, settings.signupOpenTime);
+  const closeDateTime = getDateTimeInWeek(weekSunday, settings.signupCloseDayOfWeek, settings.signupCloseTime);
+
+  // Support close times that roll past the configured open point.
+  if (closeDateTime <= openDateTime) {
+    closeDateTime.setDate(closeDateTime.getDate() + 7);
+  }
+
+  return {
+    weekSunday: new Date(weekSunday),
+    openDateTime,
+    closeDateTime,
+  };
+}
+
+function isWithinSignupWindow(now: Date, window: SignupWindow): boolean {
+  return now >= window.openDateTime && now < window.closeDateTime;
+}
+
+export function getSignupCycleState(now: Date, settings: SignupSettings): SignupCycleState {
+  const currentSunday = getSunday(now);
+  const nextSunday = addDays(currentSunday, 7);
+  const currentWindow = getSignupWindow(currentSunday, settings);
+  const nextWindow = getSignupWindow(nextSunday, settings);
+
+  if (isWithinSignupWindow(now, currentWindow)) {
+    return {
+      isOpen: true,
+      signupWeekSunday: nextSunday,
+      currentWeekSunday: currentSunday,
+      nextOpenDateTime: nextWindow.openDateTime,
+      openDateTime: currentWindow.openDateTime,
+      closeDateTime: currentWindow.closeDateTime,
+    };
+  }
+
+  if (now < currentWindow.openDateTime) {
+    return {
+      isOpen: false,
+      signupWeekSunday: null,
+      currentWeekSunday: currentSunday,
+      nextOpenDateTime: currentWindow.openDateTime,
+      openDateTime: null,
+      closeDateTime: currentWindow.closeDateTime,
+    };
+  }
+
+  return {
+    isOpen: false,
+    signupWeekSunday: null,
+    currentWeekSunday: nextSunday,
+    nextOpenDateTime: nextWindow.openDateTime,
+    openDateTime: null,
+    closeDateTime: currentWindow.closeDateTime,
+  };
+}
+
+export function isDateInSignupWeek(
+  date: string,
+  signupWeekSunday: Date | null,
+  availableDays: string[],
+): boolean {
+  if (!signupWeekSunday) {
+    return false;
+  }
+
+  return generateWeekDates(signupWeekSunday, availableDays).includes(date);
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -7,6 +7,8 @@ import { Check } from 'lucide-react';
 interface Settings {
   signupOpenDayOfWeek: number;
   signupOpenTime: string;
+  signupCloseDayOfWeek: number;
+  signupCloseTime: string;
   availableDays: string[];
 }
 
@@ -16,6 +18,8 @@ export default function SettingsPage() {
   const [settings, setSettings] = useState<Settings>({
     signupOpenDayOfWeek: 0,
     signupOpenTime: '12:00',
+    signupCloseDayOfWeek: 0,
+    signupCloseTime: '16:00',
     availableDays: ["Monday", "Tuesday", "Thursday"]
   });
   const [adminPassword, setAdminPassword] = useState('');
@@ -132,6 +136,31 @@ export default function SettingsPage() {
               type="time"
               value={settings.signupOpenTime}
               onChange={(e) => setSettings({...settings, signupOpenTime: e.target.value})}
+              className="w-full p-2 border rounded-md focus:ring-2 focus:ring-blue-500 focus:outline-none"
+            />
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div className="space-y-2">
+            <label className="block text-sm font-medium text-gray-700">Signups Close Day</label>
+            <select
+              value={settings.signupCloseDayOfWeek}
+              onChange={(e) => setSettings({...settings, signupCloseDayOfWeek: parseInt(e.target.value)})}
+              className="w-full p-2 border rounded-md focus:ring-2 focus:ring-blue-500 focus:outline-none"
+            >
+              {DAYS_OF_WEEK.map((day, idx) => (
+                <option key={day} value={idx}>{day}</option>
+              ))}
+            </select>
+          </div>
+
+          <div className="space-y-2">
+            <label className="block text-sm font-medium text-gray-700">Signups Close Time (EST)</label>
+            <input
+              type="time"
+              value={settings.signupCloseTime}
+              onChange={(e) => setSettings({...settings, signupCloseTime: e.target.value})}
               className="w-full p-2 border rounded-md focus:ring-2 focus:ring-blue-500 focus:outline-none"
             />
           </div>

--- a/app/signups/page.tsx
+++ b/app/signups/page.tsx
@@ -1,9 +1,15 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { format, addDays, Day } from 'date-fns';
+import { format } from 'date-fns';
 import { AdminLoginModal } from '../components/AdminLoginModal';
 import { Trash2, Plus, Clock } from 'lucide-react';
+import {
+  generateWeekDates,
+  getEasternWallTimeNow,
+  getSignupCycleState,
+  type SignupSettings,
+} from '../lib/signups';
 
 interface Player {
   id: number;
@@ -19,11 +25,7 @@ interface Signup {
   created_at: string;
 }
 
-interface Settings {
-  signupOpenDayOfWeek: number;
-  signupOpenTime: string;
-  availableDays: string[];
-}
+type Settings = SignupSettings;
 
 export default function SignupsPage() {
   const [settings, setSettings] = useState<Settings | null>(null);
@@ -37,8 +39,8 @@ export default function SignupsPage() {
   const [actionPending, setActionPending] = useState<(() => Promise<void>) | null>(null);
 
   useEffect(() => {
-    setNow(new Date());
-    const interval = setInterval(() => setNow(new Date()), 1000);
+    setNow(getEasternWallTimeNow());
+    const interval = setInterval(() => setNow(getEasternWallTimeNow()), 1000);
     fetchData();
     return () => clearInterval(interval);
   }, []);
@@ -50,7 +52,6 @@ export default function SignupsPage() {
         fetch('/api/players'),
         fetch('/api/signups')
       ]);
-
       if (settingsRes.ok) setSettings(await settingsRes.json());
       if (playersRes.ok) setPlayers(await playersRes.json());
       if (signupsRes.ok) setSignups(await signupsRes.json());
@@ -61,104 +62,42 @@ export default function SignupsPage() {
     }
   };
 
-  const getUpcomingDates = () => {
-    if (!settings || !settings.availableDays.length || !now) return [];
-    
-    const dates: string[] = [];
-    
-    // 1. Current Week (Sun to Sat)
-    const currentWeekStart = new Date(now);
-    currentWeekStart.setDate(now.getDate() - now.getDay()); // Sunday
-    
-    // 2. Next Week (Sun to Sat)
-    const nextWeekStart = new Date(currentWeekStart);
-    nextWeekStart.setDate(currentWeekStart.getDate() + 7);
-    
-    const generateWeekDates = (weekStart: Date) => {
-        const weekDates: string[] = [];
-        let d = new Date(weekStart);
-        for (let i = 0; i < 7; i++) {
-            const dayName = format(d, 'EEEE');
-            if (settings.availableDays.includes(dayName)) {
-                weekDates.push(format(d, 'yyyy-MM-dd'));
-            }
-            d = addDays(d, 1);
-        }
-        return weekDates;
-    };
-    
-    const currentWeekDates = generateWeekDates(currentWeekStart);
-    const nextWeekDates = generateWeekDates(nextWeekStart);
-    
-    // Tomorrow (since we move "today" to previous week)
-    const tomorrowStr = format(addDays(new Date(), 1), 'yyyy-MM-dd');
-    
-    // Add current week dates that are >= tomorrow
-    currentWeekDates.forEach(dateStr => {
-        if (dateStr >= tomorrowStr) {
-            dates.push(dateStr);
-        }
-    });
-    
-    // For next week, check if it has opened
-    const [hours, minutes] = settings.signupOpenTime.split(':').map(Number);
-    const openDateTime = new Date(currentWeekStart);
-    openDateTime.setDate(currentWeekStart.getDate() + settings.signupOpenDayOfWeek);
-    openDateTime.setHours(hours, minutes, 0, 0);
-    
-    if (now >= openDateTime) {
-        nextWeekDates.forEach(dateStr => {
-            dates.push(dateStr);
-        });
-    }
-    
-    return dates.sort();
-  };
-
   const handleSignup = async (date: string) => {
     if (!selectedPlayerId) return alert('Please select a player first');
-
     const doSignup = async () => {
       const res = await fetch('/api/signups', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ playerId: parseInt(selectedPlayerId), date })
       });
-
       if (res.status === 401 || res.status === 403) {
-        // Might need admin to bypass time restrictions or edit
         setActionPending(() => doSignup);
         setShowAdminModal(true);
         return;
       }
-
       if (res.ok) {
-        await fetchData(); // Refresh data
+        await fetchData();
       } else {
         const data = await res.json();
         alert(data.error || 'Failed to sign up');
       }
     };
-
     await doSignup();
   };
 
   const handleDelete = async (signupId: number) => {
     if (!confirm('Are you sure you want to remove this player?')) return;
-
     const doDelete = async () => {
       const res = await fetch('/api/signups', {
         method: 'DELETE',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ id: signupId })
       });
-
       if (res.status === 401) {
         setActionPending(() => doDelete);
         setShowAdminModal(true);
         return;
       }
-
       if (res.ok) {
         await fetchData();
       } else {
@@ -166,193 +105,266 @@ export default function SignupsPage() {
         alert(data.error || 'Failed to remove player');
       }
     };
-
     await doDelete();
   };
 
   const executePendingAction = async () => {
     setShowAdminModal(false);
     if (actionPending) {
-        await actionPending();
-        setActionPending(null);
+      await actionPending();
+      setActionPending(null);
     }
   };
 
   if (isLoading) return <div className="p-8 text-center text-gray-500">Loading signups...</div>;
 
-  const upcomingDates = getUpcomingDates();
-  const previousDates = Array.from(new Set(signups.map(s => s.date)))
-    .filter(d => !upcomingDates.includes(d))
-    .sort();
+  // Compute state
+  const state = settings && now ? getSignupCycleState(now, settings) : null;
+  const { isOpen, closeDateTime, nextOpenDateTime, signupWeekSunday, currentWeekSunday } = state ?? {
+    isOpen: false,
+    closeDateTime: new Date(),
+    nextOpenDateTime: new Date(),
+    signupWeekSunday: null,
+    currentWeekSunday: new Date(),
+    openDateTime: null,
+  };
 
-  const nextOpenDate = settings ? (() => {
-    const baseNow = new Date();
-    const [hours, minutes] = settings.signupOpenTime.split(':').map(Number);
-    const openDateTime = new Date();
-    openDateTime.setHours(hours, minutes, 0, 0);
+  // Dates available for signup (next week's play days) — only shown when open
+  const upcomingDates: string[] = (settings && isOpen && signupWeekSunday)
+    ? generateWeekDates(signupWeekSunday, settings.availableDays)
+    : [];
 
-    let daysUntilOpen = (settings.signupOpenDayOfWeek - openDateTime.getDay() + 7) % 7;
-    if (daysUntilOpen === 0 && baseNow > openDateTime) {
-       daysUntilOpen = 7;
-    }
-    openDateTime.setDate(openDateTime.getDate() + daysUntilOpen);
-    return openDateTime;
-  })() : null;
+  // Current week dates (shown at bottom as reference)
+  const currentWeekDates: string[] = settings
+    ? generateWeekDates(currentWeekSunday, settings.availableDays)
+    : [];
 
-  const timeDiffMs = nextOpenDate && now ? nextOpenDate.getTime() - now.getTime() : 0;
-  const isCountdownActive = timeDiffMs > 0;
-  const days = Math.floor(timeDiffMs / (1000 * 60 * 60 * 24));
-  const hours = Math.floor((timeDiffMs / (1000 * 60 * 60)) % 24);
-  const minutes = Math.floor((timeDiffMs / 1000 / 60) % 60);
-  const seconds = Math.floor((timeDiffMs / 1000) % 60);
+  // Countdown to next open
+  const timeDiffMs = now && nextOpenDateTime ? nextOpenDateTime.getTime() - now.getTime() : 0;
+  const countdownDays = Math.floor(timeDiffMs / (1000 * 60 * 60 * 24));
+  const countdownHours = Math.floor((timeDiffMs / (1000 * 60 * 60)) % 24);
+  const countdownMinutes = Math.floor((timeDiffMs / 1000 / 60) % 60);
+  const countdownSeconds = Math.floor((timeDiffMs / 1000) % 60);
+  const closeTimeDiffMs = now && closeDateTime ? Math.max(closeDateTime.getTime() - now.getTime(), 0) : 0;
+  const closeCountdownDays = Math.floor(closeTimeDiffMs / (1000 * 60 * 60 * 24));
+  const closeCountdownHours = Math.floor((closeTimeDiffMs / (1000 * 60 * 60)) % 24);
+  const closeCountdownMinutes = Math.floor((closeTimeDiffMs / 1000 / 60) % 60);
+  const closeCountdownSeconds = Math.floor((closeTimeDiffMs / 1000) % 60);
 
   return (
     <div className="max-w-4xl mx-auto p-6 space-y-8">
-      {isCountdownActive && nextOpenDate && (
-        <div className="bg-blue-50 border border-blue-200 rounded-lg p-5 flex flex-col items-center justify-center text-blue-800 shadow-sm">
-            <h2 className="text-sm font-semibold uppercase tracking-wide text-blue-600 mb-2 mt-1">Next Week&apos;s Signups Open In</h2>
-            <div className="text-4xl font-mono font-bold tabular-nums mb-2">
-                {days > 0 && `${days}d `}
-                {hours.toString().padStart(2, '0')}:{minutes.toString().padStart(2, '0')}:{seconds.toString().padStart(2, '0')}
-            </div>
-            <p className="text-sm text-blue-500 font-medium mb-1">
-                {format(nextOpenDate, 'EEEE, MMMM do')} at {format(nextOpenDate, 'h:mm a')}
-            </p>
-        </div>
-      )}
-
+      {/* Header */}
       <div className="border-b border-gray-200 pb-4 flex justify-between items-end">
         <div>
           <h1 className="text-2xl font-bold text-gray-800">Weekly Signups</h1>
-          <p className="text-gray-500 mt-1">Opt in to play for the upcoming week. Max 6 players per day.</p>
+          <p className="text-gray-500 mt-1">
+            {isOpen
+              ? 'Opt in to play for the upcoming week. Max 6 players per day.'
+              : 'Signups are currently closed.'}
+          </p>
         </div>
-        
-        <div className="flex items-center gap-2">
-           <select 
-             value={selectedPlayerId}
-             onChange={(e) => setSelectedPlayerId(e.target.value)}
-             className="p-2 border rounded-md focus:ring-2 focus:ring-blue-500 w-48"
-           >
-             <option value="">-- Who are you? --</option>
-             {[...players].sort((a, b) => a.name.localeCompare(b.name)).map(p => (
-                 <option key={p.id} value={p.id}>{p.name}</option>
-             ))}
-           </select>
-        </div>
-      </div>
-
-      <div className="space-y-6">
-        {upcomingDates.length === 0 ? (
-            <div className="text-center text-gray-500 py-8 bg-white rounded-lg border border-gray-200">
-                {(!settings || settings.availableDays.length === 0) 
-                  ? "No available playing days configured. Ask an admin to check settings."
-                  : "Signups are not currently open for any upcoming days."
-                }
-            </div>
-        ) : (
-            upcomingDates.map(dateStr => {
-                const daySignups = signups.filter(s => s.date === dateStr);
-                const registered = daySignups.filter(s => s.status === 'registered');
-                const waitlisted = daySignups.filter(s => s.status === 'waitlisted');
-                const isFull = registered.length >= 6;
-                const dateObj = new Date(dateStr + "T12:00:00");
-
-                return (
-                    <div key={dateStr} className="bg-white rounded-lg border border-gray-200 overflow-hidden shadow-sm">
-                        <div className="bg-gray-50 p-4 border-b border-gray-200 flex justify-between items-center">
-                            <div>
-                                <h2 className="text-lg font-bold text-gray-800">{format(dateObj, 'EEEE, MMMM do')}</h2>
-                                <p className="text-sm text-gray-500">{registered.length}/6 spots filled</p>
-                            </div>
-                            <button
-                                onClick={() => handleSignup(dateStr)}
-                                className={`flex items-center gap-1 px-4 py-2 rounded-md font-medium transition-colors
-                                  ${isFull 
-                                    ? 'bg-orange-100 text-orange-700 hover:bg-orange-200' 
-                                    : 'bg-blue-600 text-white hover:bg-blue-700'}`}
-                            >
-                                <Plus className="w-4 h-4" />
-                                {isFull ? 'Join Waitlist' : 'Sign Up'}
-                            </button>
-                        </div>
-                        
-                        <div className="p-0">
-                            {registered.length === 0 ? (
-                                <div className="p-4 text-center text-gray-400 italic">No one signed up yet</div>
-                            ) : (
-                                <ul className="divide-y divide-gray-100">
-                                    {registered.map((signup, idx) => (
-                                        <li key={signup.id} className="flex justify-between items-center p-3 hover:bg-gray-50 transition-colors">
-                                            <div className="flex items-center gap-3">
-                                                <span className="text-gray-400 font-mono w-4">{idx + 1}.</span>
-                                                <span className="font-medium text-gray-800">{signup.name}</span>
-                                            </div>
-                                            <button 
-                                                onClick={() => handleDelete(signup.id)}
-                                                className="text-red-400 hover:text-red-600 p-2 rounded-md hover:bg-red-50"
-                                                title="Remove player"
-                                            >
-                                                <Trash2 className="w-4 h-4" />
-                                            </button>
-                                        </li>
-                                    ))}
-                                </ul>
-                            )}
-                        </div>
-
-                        {waitlisted.length > 0 && (
-                            <div className="bg-orange-50/50 p-3 border-t border-orange-100">
-                                <h3 className="text-xs font-semibold uppercase text-orange-800 mb-2 flex items-center gap-1">
-                                    <Clock className="w-3 h-3" /> Waitlist
-                                </h3>
-                                <ul className="space-y-1">
-                                    {waitlisted.map((signup, idx) => (
-                                        <li key={signup.id} className="flex justify-between items-center text-sm text-gray-600 pl-2">
-                                            <span>{idx + 1}. {signup.name}</span>
-                                            <button 
-                                                onClick={() => handleDelete(signup.id)}
-                                                className="text-orange-400 hover:text-orange-600 p-1 rounded hover:bg-orange-100"
-                                            >
-                                                <Trash2 className="w-3 h-3" />
-                                            </button>
-                                        </li>
-                                    ))}
-                                </ul>
-                            </div>
-                        )}
-                    </div>
-                );
-            })
+        {isOpen && (
+          <div className="flex items-center gap-2">
+            <select
+              value={selectedPlayerId}
+              onChange={(e) => setSelectedPlayerId(e.target.value)}
+              className="p-2 border rounded-md focus:ring-2 focus:ring-blue-500 w-48"
+            >
+              <option value="">-- Who are you? --</option>
+              {[...players].sort((a, b) => a.name.localeCompare(b.name)).map(p => (
+                <option key={p.id} value={p.id}>{p.name}</option>
+              ))}
+            </select>
+          </div>
         )}
       </div>
 
-      {previousDates.length > 0 && (
-          <div className="pt-8 mt-8 border-t border-gray-200">
-              <h2 className="text-xl font-bold text-gray-700 mb-6">Previous Week</h2>
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                  {previousDates.map(dateStr => {
-                      const daySignups = signups.filter(s => s.date === dateStr && s.status === 'registered');
-                      if (daySignups.length === 0) return null;
-                      
-                      const dateObj = new Date(dateStr + "T12:00:00");
-                      
-                      return (
-                          <div key={dateStr} className="bg-gray-50 rounded-lg border border-gray-200 p-4 opacity-80">
-                              <h3 className="font-semibold text-gray-800 mb-3">{format(dateObj, 'EEEE, MMM do')}</h3>
-                              <ul className="space-y-1">
-                                  {daySignups.map((s, idx) => (
-                                      <li key={s.id} className="text-sm text-gray-600 flex items-center">
-                                          <span className="text-gray-400 font-mono w-4 mr-2">{idx + 1}.</span>
-                                          {s.name}
-                                      </li>
-                                  ))}
-                              </ul>
-                          </div>
-                      );
-                  })}
-              </div>
+      {/* Main body */}
+      {isOpen ? (
+        /* OPEN: show upcoming (next week) signup cards */
+        <div className="space-y-6">
+          <div className="mx-auto w-full max-w-2xl rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-center text-amber-900 md:w-1/2">
+            <div className="text-sm">
+              <span className="font-semibold">Signups close in: </span>
+              <span className="font-mono tabular-nums">
+                {closeCountdownDays > 0 && `${closeCountdownDays}d `}
+                {closeCountdownHours.toString().padStart(2, '0')}:
+                {closeCountdownMinutes.toString().padStart(2, '0')}:
+                {closeCountdownSeconds.toString().padStart(2, '0')}
+              </span>
+            </div>
+            <div className="mt-1 text-xs font-medium text-amber-700">
+              Closes {format(closeDateTime, 'EEEE')} at {format(closeDateTime, 'h:mm a')}
+            </div>
           </div>
+
+          {upcomingDates.length === 0 ? (
+            <div className="text-center text-gray-500 py-8 bg-white rounded-lg border border-gray-200">
+              {(!settings || settings.availableDays.length === 0)
+                ? 'No available playing days configured. Ask an admin to check settings.'
+                : 'Signups are not currently open for any upcoming days.'}
+            </div>
+          ) : (
+            upcomingDates.map(dateStr => {
+              const daySignups = signups.filter(s => s.date === dateStr);
+              const registered = daySignups.filter(s => s.status === 'registered');
+              const waitlisted = daySignups.filter(s => s.status === 'waitlisted');
+              const isFull = registered.length >= 6;
+              const dateObj = new Date(dateStr + 'T12:00:00');
+
+              return (
+                <div key={dateStr} className="bg-white rounded-lg border border-gray-200 overflow-hidden shadow-sm">
+                  <div className="bg-gray-50 p-4 border-b border-gray-200 flex justify-between items-center">
+                    <div>
+                      <h2 className="text-lg font-bold text-gray-800">{format(dateObj, 'EEEE, MMMM do')}</h2>
+                      <p className="text-sm text-gray-500">{registered.length}/6 spots filled</p>
+                    </div>
+                    <button
+                      onClick={() => handleSignup(dateStr)}
+                      className={`flex items-center gap-1 px-4 py-2 rounded-md font-medium transition-colors
+                        ${isFull
+                          ? 'bg-orange-100 text-orange-700 hover:bg-orange-200'
+                          : 'bg-blue-600 text-white hover:bg-blue-700'}`}
+                    >
+                      <Plus className="w-4 h-4" />
+                      {isFull ? 'Join Waitlist' : 'Sign Up'}
+                    </button>
+                  </div>
+
+                  <div className="p-0">
+                    {registered.length === 0 ? (
+                      <div className="p-4 text-center text-gray-400 italic">No one signed up yet</div>
+                    ) : (
+                      <ul className="divide-y divide-gray-100">
+                        {registered.map((signup, idx) => (
+                          <li key={signup.id} className="flex justify-between items-center p-3 hover:bg-gray-50 transition-colors">
+                            <div className="flex items-center gap-3">
+                              <span className="text-gray-400 font-mono w-4">{idx + 1}.</span>
+                              <span className="font-medium text-gray-800">{signup.name}</span>
+                            </div>
+                            <button
+                              onClick={() => handleDelete(signup.id)}
+                              className="text-red-400 hover:text-red-600 p-2 rounded-md hover:bg-red-50"
+                              title="Remove player"
+                            >
+                              <Trash2 className="w-4 h-4" />
+                            </button>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+
+                  {waitlisted.length > 0 && (
+                    <div className="bg-orange-50/50 p-3 border-t border-orange-100">
+                      <h3 className="text-xs font-semibold uppercase text-orange-800 mb-2 flex items-center gap-1">
+                        <Clock className="w-3 h-3" /> Waitlist
+                      </h3>
+                      <ul className="space-y-1">
+                        {waitlisted.map((signup, idx) => (
+                          <li key={signup.id} className="flex justify-between items-center text-sm text-gray-600 pl-2">
+                            <span>{idx + 1}. {signup.name}</span>
+                            <button
+                              onClick={() => handleDelete(signup.id)}
+                              className="text-orange-400 hover:text-orange-600 p-1 rounded hover:bg-orange-100"
+                            >
+                              <Trash2 className="w-3 h-3" />
+                            </button>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                </div>
+              );
+            })
+          )}
+        </div>
+      ) : (
+        /* CLOSED: show countdown timer */
+        nextOpenDateTime && (
+          <div className="rounded-lg border border-slate-200 bg-slate-50/80 px-4 py-4 text-slate-700">
+            <div className="mb-3 text-center text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+              Next Week&apos;s Signups Open In
+            </div>
+            <div className="mx-auto grid max-w-2xl grid-cols-4 gap-2 text-center">
+              <div className="rounded-md border border-slate-200/80 bg-white/85 px-2 py-2">
+                <div className="font-mono text-xl font-medium tabular-nums text-slate-700 md:text-2xl">
+                  {countdownDays.toString().padStart(2, '0')}
+                </div>
+                <div className="mt-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-slate-400">
+                  Days
+                </div>
+              </div>
+              <div className="rounded-md border border-slate-200/80 bg-white/85 px-2 py-2">
+                <div className="font-mono text-xl font-medium tabular-nums text-slate-700 md:text-2xl">
+                  {countdownHours.toString().padStart(2, '0')}
+                </div>
+                <div className="mt-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-slate-400">
+                  Hours
+                </div>
+              </div>
+              <div className="rounded-md border border-slate-200/80 bg-white/85 px-2 py-2">
+                <div className="font-mono text-xl font-medium tabular-nums text-slate-700 md:text-2xl">
+                  {countdownMinutes.toString().padStart(2, '0')}
+                </div>
+                <div className="mt-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-slate-400">
+                  Minutes
+                </div>
+              </div>
+              <div className="rounded-md border border-slate-200/80 bg-white/85 px-2 py-2">
+                <div className="font-mono text-xl font-medium tabular-nums text-rose-500 md:text-2xl">
+                  {countdownSeconds.toString().padStart(2, '0')}
+                </div>
+                <div className="mt-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-slate-400">
+                  Seconds
+                </div>
+              </div>
+            </div>
+            <div className="mt-2 text-center">
+              <span className="text-xs font-medium text-slate-500">
+                Opens {format(nextOpenDateTime, 'EEEE, MMMM do')} at {format(nextOpenDateTime, 'h:mm a')}
+              </span>
+            </div>
+          </div>
+        )
       )}
+
+      {/* Current Week (bottom section) */}
+      {currentWeekDates.length > 0 && (() => {
+        const currentWeekCards = currentWeekDates
+          .map(dateStr => ({
+            dateStr,
+            daySignups: signups.filter(s => s.date === dateStr && s.status === 'registered'),
+          }))
+          .filter(({ daySignups }) => daySignups.length > 0);
+
+        if (currentWeekCards.length === 0) return null;
+
+        return (
+          <div className="pt-8 mt-8 border-t border-gray-200">
+            <h2 className="text-xl font-bold text-gray-700 mb-6">Current Week</h2>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              {currentWeekCards.map(({ dateStr, daySignups }) => {
+                const dateObj = new Date(dateStr + 'T12:00:00');
+                return (
+                  <div key={dateStr} className="bg-gray-50 rounded-lg border border-gray-200 p-4 opacity-80">
+                    <h3 className="font-semibold text-gray-800 mb-3">{format(dateObj, 'EEEE, MMM do')}</h3>
+                    <ul className="space-y-1">
+                      {daySignups.map((s, idx) => (
+                        <li key={s.id} className="text-sm text-gray-600 flex items-center">
+                          <span className="text-gray-400 font-mono w-4 mr-2">{idx + 1}.</span>
+                          {s.name}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        );
+      })()}
 
       <AdminLoginModal
         isOpen={showAdminModal}

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -69,6 +69,8 @@ export const siteSettings = pgTable("site_settings", {
   adminPasswordHash: text("admin_password_hash"),
   signupOpenDayOfWeek: integer("signup_open_day_of_week").default(0), // 0 = Sunday
   signupOpenTime: text("signup_open_time").default("12:00"), // HH:mm
+  signupCloseDayOfWeek: integer("signup_close_day_of_week").default(0), // 0 = Sunday
+  signupCloseTime: text("signup_close_time").default("16:00"), // HH:mm
   availableDays: text("available_days").default(JSON.stringify(["Monday", "Tuesday", "Thursday"])),
 });
 

--- a/migrations/008_add_signup_close_settings.sql
+++ b/migrations/008_add_signup_close_settings.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "site_settings"
+ADD COLUMN IF NOT EXISTS "signup_close_day_of_week" integer DEFAULT 0;
+--> statement-breakpoint
+ALTER TABLE "site_settings"
+ADD COLUMN IF NOT EXISTS "signup_close_time" text DEFAULT '16:00';


### PR DESCRIPTION
## Summary
- add configurable signup close settings and migration support
- unify signup window logic across the signups page and API so the current week opens signups for the following week and closes correctly
- refresh the open/closed countdown UI and add targeted signup cycle tests

## Verification
- npm test -- __tests__/api/signups.test.ts app/lib/__tests__/signups.test.ts
- npx eslint app/signups/page.tsx
- npm run context:generate
- npm run context:check