### PR TITLE
Fix signup settings day and time handling

### DIFF
--- a/__tests__/api/settings.test.ts
+++ b/__tests__/api/settings.test.ts
@@ -60,9 +60,9 @@ describe('/api/settings', () => {
       if (queryType === 'settings') {
         return Promise.resolve([{
           signup_open_day_of_week: 2,
-          signup_open_time: '10:00',
+          signup_open_time: '10:00:00',
           signup_close_day_of_week: 3,
-          signup_close_time: '14:00',
+          signup_close_time: '14:00:59',
           available_days: '["Tuesday","Thursday"]',
         }]);
       }

--- a/__tests__/components/SettingsPage.test.tsx
+++ b/__tests__/components/SettingsPage.test.tsx
@@ -14,9 +14,9 @@ describe('SettingsPage', () => {
           ok: true,
           json: async () => ({
             signupOpenDayOfWeek: 0,
-            signupOpenTime: '12:00',
+            signupOpenTime: '12:00:00',
             signupCloseDayOfWeek: 0,
-            signupCloseTime: '16:00',
+            signupCloseTime: '16:00:59',
             availableDays: ['Monday', 'Tuesday', 'Thursday'],
           }),
         } as Response);
@@ -51,6 +51,8 @@ describe('SettingsPage', () => {
 
     expect(await screen.findByText('Site Settings')).toBeInTheDocument();
     expect((screen.getAllByRole('combobox')[0] as HTMLSelectElement).value).toBe('0');
+    expect((screen.getAllByDisplayValue('12:00')[0] as HTMLInputElement).value).toBe('12:00');
+    expect((screen.getAllByDisplayValue('16:00')[0] as HTMLInputElement).value).toBe('16:00');
 
     fireEvent.change(screen.getAllByRole('combobox')[0], { target: { value: '2' } });
     fireEvent.change(screen.getByPlaceholderText('Leave blank to keep current password'), { target: { value: 'new-secret' } });

--- a/__tests__/components/SignupsPage.test.tsx
+++ b/__tests__/components/SignupsPage.test.tsx
@@ -25,7 +25,7 @@ describe('SignupsPage', () => {
             signupOpenTime: '12:00',
             signupCloseDayOfWeek: 0,
             signupCloseTime: '16:00',
-            availableDays: ['Monday', 'Tuesday', 'Thursday'],
+            availableDays: ['Monday', 'Thursday'],
           }),
         } as Response);
       }
@@ -40,7 +40,7 @@ describe('SignupsPage', () => {
         } as Response);
       }
 
-      if (requestUrl === '/api/signups' && !options) {
+      if (requestUrl === '/api/signups' && (!options || !options.method)) {
         return Promise.resolve({
           ok: true,
           json: async () => [
@@ -87,6 +87,8 @@ describe('SignupsPage', () => {
 
     expect(await screen.findByText('Weekly Signups')).toBeInTheDocument();
     expect(await screen.findByText('Monday, January 19th')).toBeInTheDocument();
+    expect(screen.queryByText('Tuesday, January 20th')).not.toBeInTheDocument();
+    expect(screen.getByText('Thursday, January 22nd')).toBeInTheDocument();
 
     fireEvent.change(screen.getByRole('combobox'), { target: { value: '1' } });
     fireEvent.click(screen.getAllByText('Sign Up')[0]);

--- a/agent-context/graph.json
+++ b/agent-context/graph.json
@@ -269,9 +269,13 @@
       "file": "app/api/settings/route.ts",
       "type": "api-route",
       "tags": [],
-      "imports": [],
+      "imports": [
+        "app/lib/signups.ts"
+      ],
       "importedBy": [],
-      "related": [],
+      "related": [
+        "app/lib/signups.ts"
+      ],
       "overrideNotes": []
     },
     {
@@ -865,11 +869,15 @@
       "tags": [],
       "imports": [],
       "importedBy": [
+        "app/api/settings/route.ts",
         "app/api/signups/route.ts",
+        "app/settings/page.tsx",
         "app/signups/page.tsx"
       ],
       "related": [
+        "app/api/settings/route.ts",
         "app/api/signups/route.ts",
+        "app/settings/page.tsx",
         "app/signups/page.tsx"
       ],
       "overrideNotes": []
@@ -1034,11 +1042,13 @@
       "type": "page",
       "tags": [],
       "imports": [
-        "app/components/AdminLoginModal.tsx"
+        "app/components/AdminLoginModal.tsx",
+        "app/lib/signups.ts"
       ],
       "importedBy": [],
       "related": [
-        "app/components/AdminLoginModal.tsx"
+        "app/components/AdminLoginModal.tsx",
+        "app/lib/signups.ts"
       ],
       "overrideNotes": []
     },

--- a/agent-context/routes.json
+++ b/agent-context/routes.json
@@ -181,7 +181,9 @@
       "route": "/api/settings",
       "file": "app/api/settings/route.ts",
       "params": [],
-      "likelySourceFiles": []
+      "likelySourceFiles": [
+        "app/lib/signups.ts"
+      ]
     },
     {
       "kind": "api",
@@ -252,7 +254,8 @@
       "file": "app/settings/page.tsx",
       "params": [],
       "likelySourceFiles": [
-        "app/components/AdminLoginModal.tsx"
+        "app/components/AdminLoginModal.tsx",
+        "app/lib/signups.ts"
       ]
     },
     {

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -5,7 +5,7 @@ import {
   DEFAULT_SIGNUP_SETTINGS,
   normalizeTimeInputValue,
   parseAvailableDays,
-} from '@/app/lib/signups';
+} from '../../lib/signups';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -1,6 +1,14 @@
 import { NextResponse } from 'next/server';
 import { neon } from '@neondatabase/serverless';
 import { cookies } from 'next/headers';
+import {
+  DEFAULT_SIGNUP_SETTINGS,
+  normalizeTimeInputValue,
+  parseAvailableDays,
+} from '@/app/lib/signups';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
 
 export async function GET() {
   try {
@@ -15,22 +23,22 @@ export async function GET() {
     
     if (settings.length > 0) {
       return NextResponse.json({
-        signupOpenDayOfWeek: settings[0].signup_open_day_of_week,
-        signupOpenTime: settings[0].signup_open_time,
-        signupCloseDayOfWeek: settings[0].signup_close_day_of_week ?? 0,
-        signupCloseTime: settings[0].signup_close_time ?? '16:00',
-        availableDays: JSON.parse(settings[0].available_days || '["Monday", "Tuesday", "Thursday"]')
+        signupOpenDayOfWeek: settings[0].signup_open_day_of_week ?? DEFAULT_SIGNUP_SETTINGS.signupOpenDayOfWeek,
+        signupOpenTime: normalizeTimeInputValue(
+          settings[0].signup_open_time,
+          DEFAULT_SIGNUP_SETTINGS.signupOpenTime,
+        ),
+        signupCloseDayOfWeek: settings[0].signup_close_day_of_week ?? DEFAULT_SIGNUP_SETTINGS.signupCloseDayOfWeek,
+        signupCloseTime: normalizeTimeInputValue(
+          settings[0].signup_close_time,
+          DEFAULT_SIGNUP_SETTINGS.signupCloseTime,
+        ),
+        availableDays: parseAvailableDays(settings[0].available_days)
       });
     }
     
     // Defaults matching our schema
-    return NextResponse.json({
-      signupOpenDayOfWeek: 0, // Sunday
-      signupOpenTime: '12:00', // Noon
-      signupCloseDayOfWeek: 0, // Sunday
-      signupCloseTime: '16:00', // 4 PM
-      availableDays: ["Monday", "Tuesday", "Thursday"]
-    });
+    return NextResponse.json(DEFAULT_SIGNUP_SETTINGS);
   } catch (error) {
     console.error('Error fetching settings:', error);
     return NextResponse.json(
@@ -50,6 +58,14 @@ export async function PUT(request: Request) {
     }
 
     const body = await request.json();
+    const normalizedOpenTime = normalizeTimeInputValue(
+      body.signupOpenTime,
+      DEFAULT_SIGNUP_SETTINGS.signupOpenTime,
+    );
+    const normalizedCloseTime = normalizeTimeInputValue(
+      body.signupCloseTime,
+      DEFAULT_SIGNUP_SETTINGS.signupCloseTime,
+    );
     
     if (!process.env.DATABASE_URL) {
       throw new Error('Database URL not configured');
@@ -65,9 +81,9 @@ export async function PUT(request: Request) {
         UPDATE site_settings 
         SET 
           signup_open_day_of_week = COALESCE(${body.signupOpenDayOfWeek}, signup_open_day_of_week),
-          signup_open_time = COALESCE(${body.signupOpenTime}, signup_open_time),
+          signup_open_time = COALESCE(${normalizedOpenTime}, signup_open_time),
           signup_close_day_of_week = COALESCE(${body.signupCloseDayOfWeek}, signup_close_day_of_week),
-          signup_close_time = COALESCE(${body.signupCloseTime}, signup_close_time),
+          signup_close_time = COALESCE(${normalizedCloseTime}, signup_close_time),
           available_days = COALESCE(${JSON.stringify(body.availableDays)}, available_days),
           admin_password_hash = COALESCE(${body.adminPassword}, admin_password_hash)
         WHERE id = ${existing[0].id}
@@ -77,10 +93,10 @@ export async function PUT(request: Request) {
         INSERT INTO site_settings (signup_open_day_of_week, signup_open_time, signup_close_day_of_week, signup_close_time, available_days, admin_password_hash)
         VALUES (
           ${body.signupOpenDayOfWeek ?? 0}, 
-          ${body.signupOpenTime || '12:00'}, 
+          ${normalizedOpenTime}, 
           ${body.signupCloseDayOfWeek ?? 0},
-          ${body.signupCloseTime || '16:00'},
-          ${JSON.stringify(body.availableDays || ["Monday", "Tuesday", "Thursday"])},
+          ${normalizedCloseTime},
+          ${JSON.stringify(body.availableDays || DEFAULT_SIGNUP_SETTINGS.availableDays)},
           ${body.adminPassword || 'admin'}
         )
       `;

--- a/app/api/signups/route.ts
+++ b/app/api/signups/route.ts
@@ -2,11 +2,16 @@ import { NextResponse } from 'next/server';
 import { neon } from '@neondatabase/serverless';
 import { cookies } from 'next/headers';
 import {
+  DEFAULT_SIGNUP_SETTINGS,
   getEasternWallTimeNow,
   getSignupCycleState,
   isDateInSignupWeek,
+  parseAvailableDays,
   type SignupSettings,
 } from '../../lib/signups';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
 
 export async function GET(request: Request) {
   try {
@@ -74,19 +79,13 @@ export async function POST(request: Request) {
     if (!isAdmin) {
       const signupSettings: SignupSettings = settings.length > 0
         ? {
-            signupOpenDayOfWeek: settings[0].signup_open_day_of_week ?? 0,
-            signupOpenTime: settings[0].signup_open_time ?? '12:00',
-            signupCloseDayOfWeek: settings[0].signup_close_day_of_week ?? 0,
-            signupCloseTime: settings[0].signup_close_time ?? '16:00',
-            availableDays: JSON.parse(settings[0].available_days || '["Monday","Tuesday","Thursday"]'),
+            signupOpenDayOfWeek: settings[0].signup_open_day_of_week ?? DEFAULT_SIGNUP_SETTINGS.signupOpenDayOfWeek,
+            signupOpenTime: settings[0].signup_open_time ?? DEFAULT_SIGNUP_SETTINGS.signupOpenTime,
+            signupCloseDayOfWeek: settings[0].signup_close_day_of_week ?? DEFAULT_SIGNUP_SETTINGS.signupCloseDayOfWeek,
+            signupCloseTime: settings[0].signup_close_time ?? DEFAULT_SIGNUP_SETTINGS.signupCloseTime,
+            availableDays: parseAvailableDays(settings[0].available_days),
           }
-        : {
-            signupOpenDayOfWeek: 0,
-            signupOpenTime: '12:00',
-            signupCloseDayOfWeek: 0,
-            signupCloseTime: '16:00',
-            availableDays: ['Monday', 'Tuesday', 'Thursday'],
-          };
+        : DEFAULT_SIGNUP_SETTINGS;
 
       const signupState = getSignupCycleState(getEasternWallTimeNow(), signupSettings);
       if (!signupState.isOpen || !isDateInSignupWeek(date, signupState.signupWeekSunday, signupSettings.availableDays)) {

--- a/app/lib/signups.ts
+++ b/app/lib/signups.ts
@@ -8,6 +8,63 @@ export interface SignupSettings {
   availableDays: string[];
 }
 
+export const DEFAULT_SIGNUP_SETTINGS: SignupSettings = {
+  signupOpenDayOfWeek: 0,
+  signupOpenTime: '12:00',
+  signupCloseDayOfWeek: 0,
+  signupCloseTime: '16:00',
+  availableDays: ['Monday', 'Tuesday', 'Thursday'],
+};
+
+export function parseAvailableDays(rawAvailableDays: string | null | undefined): string[] {
+  if (!rawAvailableDays) {
+    return DEFAULT_SIGNUP_SETTINGS.availableDays;
+  }
+
+  try {
+    const parsed = JSON.parse(rawAvailableDays);
+    if (Array.isArray(parsed) && parsed.every((day) => typeof day === 'string')) {
+      return parsed;
+    }
+  } catch {
+    // Fall through to defaults when stored JSON is malformed.
+  }
+
+  return DEFAULT_SIGNUP_SETTINGS.availableDays;
+}
+
+export function normalizeTimeInputValue(
+  rawTime: string | null | undefined,
+  fallback: string,
+): string {
+  if (!rawTime) {
+    return fallback;
+  }
+
+  const match = rawTime.match(/(\d{2}):(\d{2})/);
+  if (!match) {
+    return fallback;
+  }
+
+  const [, hours, minutes] = match;
+  const normalized = `${hours}:${minutes}`;
+  const normalizedHours = Number(hours);
+  const normalizedMinutes = Number(minutes);
+
+  if (
+    !Number.isInteger(normalizedHours) ||
+    !Number.isInteger(normalizedMinutes) ||
+    normalizedHours < 0 ||
+    normalizedHours > 23 ||
+    normalizedMinutes < 0 ||
+    normalizedMinutes > 59
+  ) {
+    return fallback;
+  }
+
+  return normalized;
+}
+
 interface SignupWindow {
   weekSunday: Date;
   openDateTime: Date;

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import { AdminLoginModal } from '../components/AdminLoginModal';
 import { Check } from 'lucide-react';
+import { DEFAULT_SIGNUP_SETTINGS, normalizeTimeInputValue } from '../lib/signups';
 
 interface Settings {
   signupOpenDayOfWeek: number;
@@ -16,11 +17,7 @@ const DAYS_OF_WEEK = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "F
 
 export default function SettingsPage() {
   const [settings, setSettings] = useState<Settings>({
-    signupOpenDayOfWeek: 0,
-    signupOpenTime: '12:00',
-    signupCloseDayOfWeek: 0,
-    signupCloseTime: '16:00',
-    availableDays: ["Monday", "Tuesday", "Thursday"]
+    ...DEFAULT_SIGNUP_SETTINGS,
   });
   const [adminPassword, setAdminPassword] = useState('');
   
@@ -32,10 +29,22 @@ export default function SettingsPage() {
   useEffect(() => {
     const fetchSettings = async () => {
       try {
-        const response = await fetch('/api/settings');
+        const response = await fetch('/api/settings', { cache: 'no-store' });
         if (response.ok) {
           const data = await response.json();
-          setSettings(data);
+          setSettings({
+            signupOpenDayOfWeek: data.signupOpenDayOfWeek ?? DEFAULT_SIGNUP_SETTINGS.signupOpenDayOfWeek,
+            signupOpenTime: normalizeTimeInputValue(
+              data.signupOpenTime,
+              DEFAULT_SIGNUP_SETTINGS.signupOpenTime,
+            ),
+            signupCloseDayOfWeek: data.signupCloseDayOfWeek ?? DEFAULT_SIGNUP_SETTINGS.signupCloseDayOfWeek,
+            signupCloseTime: normalizeTimeInputValue(
+              data.signupCloseTime,
+              DEFAULT_SIGNUP_SETTINGS.signupCloseTime,
+            ),
+            availableDays: Array.isArray(data.availableDays) ? data.availableDays : DEFAULT_SIGNUP_SETTINGS.availableDays,
+          });
         }
       } catch (error) {
         console.error('Failed to fetch settings:', error);
@@ -53,6 +62,14 @@ export default function SettingsPage() {
 
     try {
       const payload: Settings & { adminPassword?: string } = { ...settings };
+      payload.signupOpenTime = normalizeTimeInputValue(
+        payload.signupOpenTime,
+        DEFAULT_SIGNUP_SETTINGS.signupOpenTime,
+      );
+      payload.signupCloseTime = normalizeTimeInputValue(
+        payload.signupCloseTime,
+        DEFAULT_SIGNUP_SETTINGS.signupCloseTime,
+      );
       if (adminPassword) {
         payload.adminPassword = adminPassword;
       }
@@ -176,6 +193,7 @@ export default function SettingsPage() {
               return (
                 <button
                   key={day}
+                  type="button"
                   onClick={() => handleToggleAvailableDay(day)}
                   className={`px-4 py-2 border rounded-full flex items-center gap-2 transition-colors
                     ${isActive ? 'bg-blue-50 border-blue-500 text-blue-700' : 'bg-gray-50 border-gray-300 text-gray-600 hover:bg-gray-100'}
@@ -208,6 +226,7 @@ export default function SettingsPage() {
 
       <div className="flex justify-end">
         <button
+          type="button"
           onClick={() => {
             void handleSave();
           }}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -137,8 +137,9 @@ export default function SettingsPage() {
         
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           <div className="space-y-2">
-            <label className="block text-sm font-medium text-gray-700">Signups Open Day</label>
+            <label htmlFor="signup-open-day" className="block text-sm font-medium text-gray-700">Signups Open Day</label>
             <select
+              id="signup-open-day"
               value={settings.signupOpenDayOfWeek}
               onChange={(e) => setSettings({...settings, signupOpenDayOfWeek: parseInt(e.target.value)})}
               className="w-full p-2 border rounded-md focus:ring-2 focus:ring-blue-500 focus:outline-none"
@@ -150,8 +151,9 @@ export default function SettingsPage() {
           </div>
 
           <div className="space-y-2">
-            <label className="block text-sm font-medium text-gray-700">Signups Open Time (EST)</label>
+            <label htmlFor="signup-open-time" className="block text-sm font-medium text-gray-700">Signups Open Time (EST)</label>
             <input
+              id="signup-open-time"
               type="time"
               value={settings.signupOpenTime}
               onChange={(e) => setSettings({...settings, signupOpenTime: e.target.value})}
@@ -162,8 +164,9 @@ export default function SettingsPage() {
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           <div className="space-y-2">
-            <label className="block text-sm font-medium text-gray-700">Signups Close Day</label>
+            <label htmlFor="signup-close-day" className="block text-sm font-medium text-gray-700">Signups Close Day</label>
             <select
+              id="signup-close-day"
               value={settings.signupCloseDayOfWeek}
               onChange={(e) => setSettings({...settings, signupCloseDayOfWeek: parseInt(e.target.value)})}
               className="w-full p-2 border rounded-md focus:ring-2 focus:ring-blue-500 focus:outline-none"
@@ -175,8 +178,9 @@ export default function SettingsPage() {
           </div>
 
           <div className="space-y-2">
-            <label className="block text-sm font-medium text-gray-700">Signups Close Time (EST)</label>
+            <label htmlFor="signup-close-time" className="block text-sm font-medium text-gray-700">Signups Close Time (EST)</label>
             <input
+              id="signup-close-time"
               type="time"
               value={settings.signupCloseTime}
               onChange={(e) => setSettings({...settings, signupCloseTime: e.target.value})}
@@ -186,7 +190,7 @@ export default function SettingsPage() {
         </div>
 
         <div className="space-y-3 pt-4 border-t border-gray-100">
-          <label className="block text-sm font-medium text-gray-700">Available Days (Target Play Days)</label>
+          <p id="available-days-label" className="block text-sm font-medium text-gray-700">Available Days (Target Play Days)</p>
           <div className="flex flex-wrap gap-2">
             {DAYS_OF_WEEK.map(day => {
               const isActive = settings.availableDays.includes(day);
@@ -194,6 +198,8 @@ export default function SettingsPage() {
                 <button
                   key={day}
                   type="button"
+                  aria-pressed={isActive}
+                  aria-describedby="available-days-label"
                   onClick={() => handleToggleAvailableDay(day)}
                   className={`px-4 py-2 border rounded-full flex items-center gap-2 transition-colors
                     ${isActive ? 'bg-blue-50 border-blue-500 text-blue-700' : 'bg-gray-50 border-gray-300 text-gray-600 hover:bg-gray-100'}
@@ -212,8 +218,9 @@ export default function SettingsPage() {
         <h2 className="text-xl font-semibold mb-4 text-gray-800">Admin Controls</h2>
         
         <div className="space-y-2">
-          <label className="block text-sm font-medium text-gray-700">Change Admin Password</label>
+          <label htmlFor="admin-password" className="block text-sm font-medium text-gray-700">Change Admin Password</label>
           <input
+            id="admin-password"
             type="password"
             value={adminPassword}
             onChange={(e) => setAdminPassword(e.target.value)}

--- a/app/signups/page.tsx
+++ b/app/signups/page.tsx
@@ -48,9 +48,9 @@ export default function SignupsPage() {
   const fetchData = async () => {
     try {
       const [settingsRes, playersRes, signupsRes] = await Promise.all([
-        fetch('/api/settings'),
-        fetch('/api/players'),
-        fetch('/api/signups')
+        fetch('/api/settings', { cache: 'no-store' }),
+        fetch('/api/players', { cache: 'no-store' }),
+        fetch('/api/signups', { cache: 'no-store' })
       ]);
       if (settingsRes.ok) setSettings(await settingsRes.json());
       if (playersRes.ok) setPlayers(await playersRes.json());


### PR DESCRIPTION
## Summary
- make signup/settings API responses dynamic and fetch them uncached so signup days reflect site settings immediately
- centralize signup settings parsing/defaults and normalize stored time values for the settings form
- add/update tests covering dynamic signup days and sanitized time values

## Testing
- npm test -- __tests__/components/SignupsPage.test.tsx
- npm test -- __tests__/components/SettingsPage.test.tsx
- npm test -- __tests__/api/settings.test.ts __tests__/api/signups.test.ts app/lib/__tests__/signups.test.ts