### PR TITLE
chore: safeguard production db from preview setups

### DIFF
--- a/scripts/preview-setup.ts
+++ b/scripts/preview-setup.ts
@@ -1,6 +1,12 @@
 import { execSync } from 'child_process';
 
 function main() {
+  // Prevent running on main branch in case of accidental preview evaluations
+  if (process.env.VERCEL_GIT_COMMIT_REF === 'main') {
+    console.log('⏭️ Skipping database setup: Cannot run on main branch.');
+    return;
+  }
+
   if (process.env.VERCEL_ENV === 'preview') {
     console.log('🚧 Preview environment detected: Running database migrations and seed...');
     try {

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -4,6 +4,16 @@ import * as schema from '../db/schema';
 import { sql } from 'drizzle-orm';
 
 async function main() {
+  if (process.env.VERCEL_ENV === 'production') {
+    console.error('❌ FATAL: Cannot run seed in production environment!');
+    process.exit(1);
+  }
+
+  if (process.env.VERCEL_GIT_COMMIT_REF === 'main') {
+    console.error('❌ FATAL: Cannot run seed on the main branch!');
+    process.exit(1);
+  }
+
   const db = getDatabase();
 
   console.log('Seeding database...');


### PR DESCRIPTION
Adds branch guards to prevent preview-setup.ts and seed.ts from running on the main branch, preventing production DB overwrites during PR merges.