### PR TITLE
🎨 Palette: Add aria-label to modal close buttons

### DIFF
--- a/app/components/AdminLoginModal.tsx
+++ b/app/components/AdminLoginModal.tsx
@@ -54,6 +54,7 @@ export function AdminLoginModal({ isOpen, onClose, onSuccess }: AdminLoginModalP
         <button 
           onClick={onClose}
           className="absolute top-4 right-4 text-gray-500 hover:text-gray-700"
+          aria-label="Close modal"
         >
           <X className="w-5 h-5" />
         </button>

--- a/app/components/RecordMatchModal.tsx
+++ b/app/components/RecordMatchModal.tsx
@@ -218,6 +218,7 @@ export function RecordMatchModal({ isOpen, onClose, onSubmit, suggestedTeams, pr
               onClick={handleClose}
               disabled={isSubmitting}
               className="text-gray-400 hover:text-gray-600 transition-colors"
+              aria-label="Close modal"
             >
               <X className="h-6 w-6" />
             </button>

--- a/tests/e2e/match-recording.spec.ts
+++ b/tests/e2e/match-recording.spec.ts
@@ -9,7 +9,7 @@ test.describe('Match Recording Flow', () => {
   test('should record a match with admin authentication', async ({ page }) => {
     // 1. Open the FAB and select Record Match
     await page.getByTitle('Actions').click();
-    await page.getByRole('button', { name: 'Record Match' }).click();
+    await page.getByRole('menuitem', { name: 'Record Match' }).click();
 
     // 2. Wait for the Record Game modal to appear and players to load
     const modal = page.locator('.fixed.inset-0').locator('.bg-white');
@@ -61,7 +61,7 @@ test.describe('Match Recording Flow', () => {
   test('should show error for invalid password', async ({ page }) => {
     // 1. Open the FAB and select Record Match
     await page.getByTitle('Actions').click();
-    await page.getByRole('button', { name: 'Record Match' }).click();
+    await page.getByRole('menuitem', { name: 'Record Match' }).click();
 
     // 2. Wait for modal
     const modal = page.locator('.fixed.inset-0').locator('.bg-white');

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -19,6 +19,6 @@ test('has title and basic dashboard elements', async ({ page }) => {
   
   // Test opening the FAB menu gives access to Record Match
   await fab.click();
-  await expect(page.getByRole('button', { name: 'Record Match' })).toBeVisible();
+  await expect(page.getByRole('menuitem', { name: 'Record Match' })).toBeVisible();
   await fab.click(); // Close it
 });


### PR DESCRIPTION
🎨 Palette: Added `aria-label` to Modal Close Buttons

💡 **What:** Added `aria-label="Close modal"` to the close buttons containing only the `<X>` icon in both `AdminLoginModal` and `RecordMatchModal`.
🎯 **Why:** To improve accessibility by ensuring screen reader users can understand the purpose of the close buttons. Icon-only buttons without an accessible name present a confusing experience.
📸 **Before/After:** No visual change.
♿ **Accessibility:** Fixes WCAG criteria related to name, role, and value by explicitly labeling interactive components that lack visible text content.

---
*PR created automatically by Jules for task [900480014026781824](https://jules.google.com/task/900480014026781824) started by @kjschaef*