### PR TITLE
🎨 Palette: Add ARIA labels to ChatBot icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,6 @@
 2. They reflect their state using `aria-expanded`.
 3. They provide explicit keyboard focus styles (e.g. `focus-visible:ring`).
 4. Micro-interactions like an icon rotating (e.g. `rotate-45` on a `<Plus />` to form an `X`) provide immediate, intuitive feedback to users.
+## 2024-05-18 - ARIA labels for Icon-Only Buttons
+**Learning:** Icon-only buttons often lack accessible text, causing screen readers to announce them improperly. It is crucial to check all Button instances with size="icon" and ensure they include aria-label attributes describing their action, not just visual hints.
+**Action:** When adding or auditing icon-only components, verify the presence of explicit aria-label properties so their functionality is accessible.

--- a/app/components/ChatBot.tsx
+++ b/app/components/ChatBot.tsx
@@ -907,6 +907,7 @@ export function ChatBot({ onUseMatchup, onRecordMatch, isOpen: controlledIsOpen,
           <Button
             className="fixed bottom-6 right-28 h-14 w-14 rounded-full shadow-lg z-50 bg-gray-900 hover:bg-gray-800 transition-all duration-200 transform hover:scale-105"
             size="icon"
+            aria-label="Chat Assistant"
           >
             <MessageCircle className="h-6 w-6" />
           </Button>
@@ -1046,6 +1047,7 @@ export function ChatBot({ onUseMatchup, onRecordMatch, isOpen: controlledIsOpen,
                             size="sm"
                             onClick={() => openFeedbackDialog(index, 'positive')}
                             className="h-6 w-6 p-0 hover:bg-green-100"
+                            aria-label="Good response"
                           >
                             <ThumbsUp className="h-3 w-3 text-gray-400 hover:text-green-600" />
                           </Button>
@@ -1054,6 +1056,7 @@ export function ChatBot({ onUseMatchup, onRecordMatch, isOpen: controlledIsOpen,
                             size="sm"
                             onClick={() => openFeedbackDialog(index, 'negative')}
                             className="h-6 w-6 p-0 hover:bg-red-100"
+                            aria-label="Bad response"
                           >
                             <ThumbsDown className="h-3 w-3 text-gray-400 hover:text-red-600" />
                           </Button>
@@ -1097,6 +1100,7 @@ export function ChatBot({ onUseMatchup, onRecordMatch, isOpen: controlledIsOpen,
                   size="icon"
                   onClick={() => fileInputRef.current?.click()}
                   disabled={isLoading}
+                  aria-label="Upload image"
                 >
                   <Upload className="h-4 w-4" />
                 </Button>
@@ -1104,6 +1108,7 @@ export function ChatBot({ onUseMatchup, onRecordMatch, isOpen: controlledIsOpen,
                   onClick={() => sendMessage()}
                   disabled={isLoading || !input.trim()}
                   size="icon"
+                  aria-label="Send message"
                 >
                   <Send className="h-4 w-4" />
                 </Button>


### PR DESCRIPTION
### 💡 What
Added `aria-label` attributes to the following icon-only buttons in the `ChatBot` component:
- Chat Assistant toggle button
- Image upload button
- Send message button
- Good response (Thumbs up) feedback button
- Bad response (Thumbs down) feedback button

### 🎯 Why
Icon-only buttons rely entirely on visual cues (icons) to communicate their purpose. Screen readers and assistive technologies require explicit text alternatives to properly announce the function of these buttons to visually impaired users. Without ARIA labels, these buttons would be read as generic, unlabeled elements, hindering usability.

### 📸 Before/After
*(No visual changes - purely an accessibility enhancement)*

### ♿ Accessibility
This change ensures that screen readers will now announce the function of the chatbot interactive elements properly, following WCAG standards for non-text content.

---
*PR created automatically by Jules for task [11197986347826537823](https://jules.google.com/task/11197986347826537823) started by @kjschaef*