### PR TITLE
Change inactive player threshold to 6 months

### DIFF
--- a/__tests__/api/player-stats.test.ts
+++ b/__tests__/api/player-stats.test.ts
@@ -654,6 +654,85 @@ describe('/api/player-stats', () => {
     });
   });
 
+  describe('Last game date calculations', () => {
+    it('should calculate lastGameDate correctly', async () => {
+      const mockPlayers = [
+        { id: 1, name: 'Alice', start_year: 2020, created_at: '2020-01-01' },
+      ];
+
+      const mockMatches = [
+        {
+          id: 1,
+          team_one_player_one_id: 1,
+          team_one_player_two_id: null,
+          team_one_player_three_id: null,
+          team_two_player_one_id: null,
+          team_two_player_two_id: null,
+          team_two_player_three_id: null,
+          team_one_games_won: 3,
+          team_two_games_won: 2,
+          date: '2023-01-01T00:00:00.000Z'
+        },
+        {
+          id: 2,
+          team_one_player_one_id: null,
+          team_one_player_two_id: null,
+          team_one_player_three_id: null,
+          team_two_player_one_id: 1,
+          team_two_player_two_id: null,
+          team_two_player_three_id: null,
+          team_one_games_won: 1,
+          team_two_games_won: 4,
+          date: '2024-05-10T00:00:00.000Z'
+        }
+      ];
+
+      mockSql.mockImplementation((queryType) => {
+        if (queryType === 'players') {
+          return Promise.resolve(mockPlayers);
+        }
+        if (queryType === 'matches') {
+          return Promise.resolve(mockMatches);
+        }
+        return Promise.resolve([]);
+      });
+
+      const request = new NextRequest('http://localhost:3000/api/player-stats');
+      const response = await GET(request);
+      const playerStats = await response.json();
+
+      const alice = playerStats[0];
+
+      expect(alice.lastGameDate).toBe('2024-05-10T00:00:00.000Z');
+    });
+
+    it('should handle lastGameDate when a player has no matches', async () => {
+      const mockPlayers = [
+        { id: 1, name: 'Alice', start_year: 2020, created_at: '2020-01-01' },
+      ];
+
+      const mockMatches = [];
+
+      mockSql.mockImplementation((queryType) => {
+        if (queryType === 'players') {
+          return Promise.resolve(mockPlayers);
+        }
+        if (queryType === 'matches') {
+          return Promise.resolve(mockMatches);
+        }
+        return Promise.resolve([]);
+      });
+
+      const request = new NextRequest('http://localhost:3000/api/player-stats');
+      const response = await GET(request);
+      const playerStats = await response.json();
+
+      const alice = playerStats[0];
+
+      expect(alice.lastGameDate).toBeNull();
+    });
+  });
+
 
 
   describe('Player visibility regression tests', () => {

--- a/app/components/PlayerCards.tsx
+++ b/app/components/PlayerCards.tsx
@@ -35,6 +35,7 @@ interface PlayerStats {
   totalPlayingTime: number;
 
   actualWinPercentage?: number;
+  lastGameDate?: string | null;
 }
 
 const getWinPercentageGradient = (percentage: number): string => {
@@ -427,9 +428,19 @@ export function PlayerCards() {
     );
   }
 
-  // Split players into main (50+ games) and inactive (<50 games)
-  const mainPlayers = playerStats.filter((player) => player.record.totalGames >= 50);
-  const inactivePlayers = playerStats.filter((player) => player.record.totalGames < 50);
+  // Split players into active and inactive (> 6 months since last game)
+  const sixMonthsAgo = new Date();
+  sixMonthsAgo.setMonth(sixMonthsAgo.getMonth() - 6);
+
+  const mainPlayers = playerStats.filter((player) => {
+    if (!player.lastGameDate) return false;
+    return new Date(player.lastGameDate) >= sixMonthsAgo;
+  });
+
+  const inactivePlayers = playerStats.filter((player) => {
+    if (!player.lastGameDate) return true;
+    return new Date(player.lastGameDate) < sixMonthsAgo;
+  });
 
   return (
     <div className="space-y-8">
@@ -451,7 +462,7 @@ export function PlayerCards() {
           </div>
         ) : (
           <div className="p-6 text-center border border-gray-200 rounded-xl bg-gradient-to-br from-gray-50 to-gray-100">
-            <p className="text-gray-600">No players with 50+ games yet.</p>
+            <p className="text-gray-600">No active players yet.</p>
           </div>
         )}
       </div>
@@ -462,7 +473,7 @@ export function PlayerCards() {
           <div className="flex items-center gap-3">
             <h2 className="text-2xl font-bold text-gray-700">Inactive Players</h2>
             <span className="text-sm text-gray-500 bg-gray-100 px-2 py-1 rounded-full">
-              &lt;50 games
+              Inactive &gt; 6 mos
             </span>
           </div>
           <div className="flex flex-wrap gap-4 justify-center sm:justify-start opacity-80">

--- a/app/lib/stats.ts
+++ b/app/lib/stats.ts
@@ -11,6 +11,7 @@ export interface PlayerStats {
     totalPlayingTime: number;
 
     actualWinPercentage?: number;
+    lastGameDate?: string | null;
 }
 
 
@@ -82,6 +83,10 @@ export async function calculatePlayerStats(
             // Calculate win percentage
             const winPercentage = gamesWon + gamesLost > 0 ? (gamesWon / (gamesWon + gamesLost)) * 100 : 0;
 
+            const lastGameDate = processedMatches.length > 0
+                ? new Date(Math.max(...processedMatches.map(m => new Date(m.date).getTime()))).toISOString()
+                : null;
+
             return {
                 id: player.id,
                 name: player.name,
@@ -94,7 +99,8 @@ export async function calculatePlayerStats(
                 winPercentage,
                 totalPlayingTime,
 
-                actualWinPercentage: winPercentage
+                actualWinPercentage: winPercentage,
+                lastGameDate
             };
         } catch (error) {
             console.error(`Error processing player ${player.name} (ID ${player.id}):`, error);
@@ -107,7 +113,8 @@ export async function calculatePlayerStats(
                 winPercentage: 0,
                 totalPlayingTime: 0,
 
-                actualWinPercentage: 0
+                actualWinPercentage: 0,
+                lastGameDate: null
             };
         }
     }));


### PR DESCRIPTION
This change updates the logic for determining if a player is inactive. Instead of using a threshold of fewer than 50 total games, a player is now considered inactive if they haven't played a game in the last 6 months.

**Changes:**
1.  **`app/lib/stats.ts`:**
    *   Added `lastGameDate` to the `PlayerStats` interface.
    *   Updated `calculatePlayerStats` to calculate `lastGameDate` by finding the most recent match date for each player.
2.  **`app/components/PlayerCards.tsx`:**
    *   Updated the filtering logic for `mainPlayers` (active) and `inactivePlayers` to check if the player's `lastGameDate` is older than 6 months.
    *   Updated the UI text from `"<50 games"` to `"Inactive > 6 mos"`.
    *   Updated the empty state text from `"No players with 50+ games yet."` to `"No active players yet."`.

---
*PR created automatically by Jules for task [1231060369360402245](https://jules.google.com/task/1231060369360402245) started by @kjschaef*