### PR TITLE
🎨 Palette: Improve keyboard accessibility for player selection

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,6 @@
 ## 2024-05-18 - ARIA labels for Icon-Only Buttons
 **Learning:** Icon-only buttons often lack accessible text, causing screen readers to announce them improperly. It is crucial to check all Button instances with size="icon" and ensure they include aria-label attributes describing their action, not just visual hints.
 **Action:** When adding or auditing icon-only components, verify the presence of explicit aria-label properties so their functionality is accessible.
+## 2026-04-17 - Keyboard Accessibility for Custom Buttons
+**Learning:** Custom components using `role="button"` often lack explicit visual focus indicators (`focus-visible:ring`) and suffer from unwanted page scrolling when the Space key is pressed. They also frequently miss `aria-disabled` states when logically unselectable.
+**Action:** When implementing custom `role="button"` components, always add `focus-visible` utility classes, ensure `e.preventDefault()` is called for Space key presses to prevent scrolling, and use `aria-disabled={!isEnabled}` rather than just relying on visual styles or pointer events.

--- a/app/components/PlayerGrid.tsx
+++ b/app/components/PlayerGrid.tsx
@@ -65,11 +65,18 @@ export function PlayerGrid({
             <div
               key={player.id}
               onClick={() => canSelect && handlePlayerClick(player.id)}
-              onKeyDown={(e) => canSelect && (e.key === 'Enter' || e.key === ' ') && handlePlayerClick(player.id)}
+              onKeyDown={(e) => {
+                if (!canSelect) return;
+                if (e.key === 'Enter' || e.key === ' ') {
+                  if (e.key === ' ') e.preventDefault();
+                  handlePlayerClick(player.id);
+                }
+              }}
               tabIndex={canSelect ? 0 : -1}
               role="button"
               aria-pressed={isSelected}
-              className={`p-3 border rounded-lg cursor-pointer transition-all ${isSelected
+              aria-disabled={!canSelect}
+              className={`p-3 border rounded-lg cursor-pointer transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 ${isSelected
                 ? 'border-blue-500 bg-blue-50'
                 : canSelect
                   ? 'border-gray-200 hover:border-gray-300'


### PR DESCRIPTION
## 💡 What
Added visible focus indicators, fixed page scrolling behavior on Space key press, and added explicit `aria-disabled` states for custom player selection buttons in `PlayerGrid`. Also updated `.Jules/palette.md` with learnings on custom button accessibility.

## 🎯 Why
Custom `div` elements acting as buttons (`role="button"`) often lack built-in accessibility features that native `<button>` elements have. Without explicit styles, keyboard users can't see which element has focus. Additionally, pressing the Space bar to activate a custom button usually scrolls the page down unless explicitly prevented. Adding `aria-disabled` provides better feedback to screen readers when a player cannot be selected (e.g., when the max number of players is reached). 

## 📸 Before/After
*(Visual focus ring added on focus-visible state)*

## ♿ Accessibility
*   **Keyboard Navigation:** Users navigating via Tab now see a clear blue focus ring (`focus-visible:ring-2 focus-visible:ring-blue-500`) around focused player cards.
*   **Interaction:** Pressing Space no longer scrolls the page down, making interaction seamless.
*   **Screen Readers:** `aria-disabled` accurately conveys when a player card is unselectable, rather than just relying on visual opacity/cursor changes.

---
*PR created automatically by Jules for task [14351080726080894477](https://jules.google.com/task/14351080726080894477) started by @kjschaef*