### PR TITLE
🎨 Palette: Add aria-expanded to GameHistory accordion row

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,7 @@
 ## 2024-05-18 - ARIA labels for Icon-Only Buttons
 **Learning:** Icon-only buttons often lack accessible text, causing screen readers to announce them improperly. It is crucial to check all Button instances with size="icon" and ensure they include aria-label attributes describing their action, not just visual hints.
 **Action:** When adding or auditing icon-only components, verify the presence of explicit aria-label properties so their functionality is accessible.
+
+## 2024-05-19 - Accordion State with aria-expanded
+**Learning:** When using custom `div` elements with `role="button"` as accordion toggles, they must explicitly communicate their expanded/collapsed state to screen readers.
+**Action:** Ensure all custom toggle elements update `aria-expanded="true|false"` dynamically based on their current state.

--- a/app/components/GameHistory.tsx
+++ b/app/components/GameHistory.tsx
@@ -64,6 +64,7 @@ export function GameHistory({ games }: GameHistoryProps) {
                 onKeyDown={(e) => e.key === 'Enter' && toggleGameExpansion(game.id)}
                 tabIndex={0}
                 role="button"
+                aria-expanded={expandedGameId === game.id}
               >
                 <div className="flex flex-col sm:flex-row sm:items-center gap-2">
                   <span className="text-sm text-gray-500">


### PR DESCRIPTION
### 💡 What
Added `aria-expanded` attribute to the match summary row in the `GameHistory` component.

### 🎯 Why
The match summary row acts as a custom accordion toggle (it already had `role="button"` and keyboard navigation support). However, without `aria-expanded`, screen reader users would not know if clicking the row would expand or collapse the details.

### 📸 Before/After
No visual changes were made.

### ♿ Accessibility
- Screen readers will now announce the current state (expanded or collapsed) of the match summary accordion row, making the UI more predictable for visually impaired users.

---
*PR created automatically by Jules for task [11028193674805806746](https://jules.google.com/task/11028193674805806746) started by @kjschaef*