### PR TITLE
fix: Defer database connection initialization to fix build errors

### DIFF
--- a/agent-context/graph.json
+++ b/agent-context/graph.json
@@ -9,12 +9,12 @@
         "players"
       ],
       "imports": [
-        "db/index.ts",
+        "db/config.ts",
         "db/schema.ts"
       ],
       "importedBy": [],
       "related": [
-        "db/index.ts",
+        "db/config.ts",
         "db/schema.ts"
       ],
       "overrideNotes": []
@@ -112,12 +112,12 @@
         "matches"
       ],
       "imports": [
-        "db/index.ts",
+        "db/config.ts",
         "db/schema.ts"
       ],
       "importedBy": [],
       "related": [
-        "db/index.ts",
+        "db/config.ts",
         "db/schema.ts"
       ],
       "overrideNotes": []
@@ -129,12 +129,12 @@
         "matches"
       ],
       "imports": [
-        "db/index.ts",
+        "db/config.ts",
         "db/schema.ts"
       ],
       "importedBy": [],
       "related": [
-        "db/index.ts",
+        "db/config.ts",
         "db/schema.ts"
       ],
       "overrideNotes": []
@@ -208,12 +208,12 @@
         "players"
       ],
       "imports": [
-        "db/index.ts",
+        "db/config.ts",
         "db/schema.ts"
       ],
       "importedBy": [],
       "related": [
-        "db/index.ts",
+        "db/config.ts",
         "db/schema.ts"
       ],
       "overrideNotes": []
@@ -1092,9 +1092,17 @@
         "db/schema.ts"
       ],
       "importedBy": [
+        "app/api/achievements/check/[playerId]/route.ts",
+        "app/api/games/[id]/route.ts",
+        "app/api/games/route.ts",
+        "app/api/players/[id]/route.ts",
         "db/index.ts"
       ],
       "related": [
+        "app/api/achievements/check/[playerId]/route.ts",
+        "app/api/games/[id]/route.ts",
+        "app/api/games/route.ts",
+        "app/api/players/[id]/route.ts",
         "db/index.ts",
         "db/schema.ts"
       ],
@@ -1109,17 +1117,8 @@
       "imports": [
         "db/config.ts"
       ],
-      "importedBy": [
-        "app/api/achievements/check/[playerId]/route.ts",
-        "app/api/games/[id]/route.ts",
-        "app/api/games/route.ts",
-        "app/api/players/[id]/route.ts"
-      ],
+      "importedBy": [],
       "related": [
-        "app/api/achievements/check/[playerId]/route.ts",
-        "app/api/games/[id]/route.ts",
-        "app/api/games/route.ts",
-        "app/api/players/[id]/route.ts",
         "db/config.ts"
       ],
       "overrideNotes": []

--- a/agent-context/routes.json
+++ b/agent-context/routes.json
@@ -25,7 +25,7 @@
         "playerId"
       ],
       "likelySourceFiles": [
-        "db/index.ts",
+        "db/config.ts",
         "db/schema.ts"
       ]
     },
@@ -88,7 +88,7 @@
       "file": "app/api/games/route.ts",
       "params": [],
       "likelySourceFiles": [
-        "db/index.ts",
+        "db/config.ts",
         "db/schema.ts"
       ]
     },
@@ -100,7 +100,7 @@
         "id"
       ],
       "likelySourceFiles": [
-        "db/index.ts",
+        "db/config.ts",
         "db/schema.ts"
       ]
     },
@@ -154,7 +154,7 @@
         "id"
       ],
       "likelySourceFiles": [
-        "db/index.ts",
+        "db/config.ts",
         "db/schema.ts"
       ]
     },

--- a/app/api/achievements/check/[playerId]/route.ts
+++ b/app/api/achievements/check/[playerId]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { eq, or } from "drizzle-orm";
-import { db } from "../../../../../db";
+import { getDatabase } from "../../../../../db/config";
 import { matches, achievements, playerAchievements } from "../../../../../db/schema";
 
 export async function POST(
@@ -8,6 +8,7 @@ export async function POST(
   { params }: { params: { playerId: string } }
 ) {
   try {
+    const db = getDatabase();
     const playerId = parseInt(params.playerId);
 
     // Get player's matches and current achievements

--- a/app/api/games/[id]/route.ts
+++ b/app/api/games/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
-import { db } from "../../../../db";
+import { getDatabase } from "../../../../db/config";
 import { matches } from "../../../../db/schema";
 
 export async function DELETE(
@@ -8,6 +8,7 @@ export async function DELETE(
   { params }: { params: { id: string } }
 ) {
   try {
+    const db = getDatabase();
     const gameId = parseInt(params.id);
     // deleting game id: server
 

--- a/app/api/games/route.ts
+++ b/app/api/games/route.ts
@@ -1,9 +1,10 @@
 import { NextResponse } from "next/server";
-import { db } from "../../../db";
+import { getDatabase } from "../../../db/config";
 import { matches, players } from "../../../db/schema";
 
 export async function POST(request: Request) {
   try {
+    const db = getDatabase();
     const data = await request.json();
     // recording new game (server)
     

--- a/app/api/players/[id]/route.ts
+++ b/app/api/players/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
-import { db } from '../../../../db';
+import { getDatabase } from '../../../../db/config';
 import { players, matches } from '../../../../db/schema';
 import { eq, or } from 'drizzle-orm';
 
@@ -8,6 +8,7 @@ export async function GET(
   request: Request,
   { params }: { params: { id: string } }
 ) {
+  const db = getDatabase();
   const playerId = parseInt(params.id);
 
   if (isNaN(playerId)) {
@@ -97,6 +98,7 @@ export async function PUT(
   request: Request,
   { params }: { params: { id: string } }
 ) {
+  const db = getDatabase();
   const playerId = parseInt(params.id);
   const cookieStore = await cookies();
   const isAdmin = cookieStore.get('admin_token')?.value === 'true';
@@ -157,6 +159,7 @@ export async function DELETE(
   request: Request,
   { params }: { params: { id: string } }
 ) {
+  const db = getDatabase();
   const playerId = parseInt(params.id);
   const cookieStore = await cookies();
   const isAdmin = cookieStore.get('admin_token')?.value === 'true';


### PR DESCRIPTION
This commit fixes the failing Next.js build step in the CI pipeline for the `remove-mailgun` branch.

**What**
Several API routes were importing `db` from `db/index.ts`. Because `db/index.ts` calls `getDatabase()` globally at module import time, it causes Next.js to evaluate the database connection string logic during the build step. Since `DATABASE_URL` is typically unset during build in some Vercel/CI environments, it throws an error.

The fix removes the global import and instead calls `getDatabase()` directly inside the `GET`, `POST`, `PUT`, and `DELETE` handler functions, delaying execution until actual request time.

**Why**
To unblock the CI build and allow deployment, and to adhere to Next.js App Router best practices regarding dynamically required environment variables.

**Verification**
Locally ran `NEXT_PHASE=phase-production-build DATABASE_URL=postgres://test:test@test:5432/test OPENAI_API_KEY=test pnpm run build` and verified the build succeeds without the previous error. Also verified that `pnpm test`, `pnpm lint`, and `pnpm run context:check` pass.

---
*PR created automatically by Jules for task [13034718795273771729](https://jules.google.com/task/13034718795273771729) started by @kjschaef*