### PR TITLE
🎨 Palette: Improve keyboard accessibility in PlayerGrid

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,6 @@
 ## 2024-05-18 - ARIA labels for Icon-Only Buttons
 **Learning:** Icon-only buttons often lack accessible text, causing screen readers to announce them improperly. It is crucial to check all Button instances with size="icon" and ensure they include aria-label attributes describing their action, not just visual hints.
 **Action:** When adding or auditing icon-only components, verify the presence of explicit aria-label properties so their functionality is accessible.
+## 2025-05-19 - Keyboard Accessibility for Custom Buttons
+**Learning:** When using custom `div` elements as buttons (e.g. `role="button"`), it's critical to capture Spacebar interactions within the `onKeyDown` handler to prevent default behavior. Otherwise, pressing Space to activate the "button" causes an unwanted page scroll, breaking the expected UX. Additionally, explicit `focus-visible` styles and accurate `aria-disabled` attributes are essential for robust keyboard accessibility on these elements.
+**Action:** Always include `e.preventDefault()` for Space/Enter keys in custom button `onKeyDown` handlers, and verify focus styles/ARIA attributes are present and responsive to the component's interactive state.

--- a/app/components/PlayerGrid.tsx
+++ b/app/components/PlayerGrid.tsx
@@ -65,11 +65,17 @@ export function PlayerGrid({
             <div
               key={player.id}
               onClick={() => canSelect && handlePlayerClick(player.id)}
-              onKeyDown={(e) => canSelect && (e.key === 'Enter' || e.key === ' ') && handlePlayerClick(player.id)}
+              onKeyDown={(e) => {
+                if (canSelect && (e.key === 'Enter' || e.key === ' ')) {
+                  e.preventDefault();
+                  handlePlayerClick(player.id);
+                }
+              }}
               tabIndex={canSelect ? 0 : -1}
               role="button"
               aria-pressed={isSelected}
-              className={`p-3 border rounded-lg cursor-pointer transition-all ${isSelected
+              aria-disabled={!canSelect}
+              className={`p-3 border rounded-lg cursor-pointer transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${isSelected
                 ? 'border-blue-500 bg-blue-50'
                 : canSelect
                   ? 'border-gray-200 hover:border-gray-300'


### PR DESCRIPTION
**💡 What:**
Added critical accessibility improvements to the `PlayerGrid` component:
- Prevented default Spacebar behavior (page scroll) in the `onKeyDown` handler.
- Added `aria-disabled` for proper screen reader communication of unselectable states.
- Added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500` for clear keyboard navigation focus indicators.

**🎯 Why:**
Custom elements acting as buttons (`role="button"`) require careful handling. Previously, pressing the spacebar to select a player would cause the browser to scroll down the page, which is a frustrating UX issue for keyboard users. Furthermore, there was no visual indication of which player was currently focused during keyboard navigation, and screen readers lacked explicit context about when a player could not be selected.

**📸 Before/After:**
*(See attached Playwright screenshots in PR or verification step - Focus ring is now visible, and Spacebar selects the user without scrolling)*

**♿ Accessibility:**
Greatly improves keyboard and screen reader accessibility by ensuring focus visibility, proper ARIA states, and expected Spacebar interaction.

---
*PR created automatically by Jules for task [2390163270978809978](https://jules.google.com/task/2390163270978809978) started by @kjschaef*