### PR TITLE
🎨 Palette: Improve keyboard accessibility for custom buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,10 @@
 ## 2024-05-19 - Accordion State with aria-expanded
 **Learning:** When using custom `div` elements with `role="button"` as accordion toggles, they must explicitly communicate their expanded/collapsed state to screen readers.
 **Action:** Ensure all custom toggle elements update `aria-expanded="true|false"` dynamically based on their current state.
+
+## 2024-05-20 - Keyboard Accessibility for role="button"
+**Learning:** Custom interactive elements using `role="button"` (e.g. div or span elements acting as buttons) often lack visual focus indicators and can cause unintended scrolling when activated with the Space key. This makes them difficult to use for keyboard-only users.
+**Action:** When implementing custom interactive elements with `role="button"`, always ensure:
+1. They include explicit focus styles (e.g. `focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none`).
+2. They call `e.preventDefault()` within the `onKeyDown` handler when the Space key is pressed to avoid unwanted page scrolling.
+3. They utilize `aria-disabled` for unselectable or disabled states.

--- a/app/components/GameHistory.tsx
+++ b/app/components/GameHistory.tsx
@@ -59,9 +59,14 @@ export function GameHistory({ games }: GameHistoryProps) {
             >
               {/* Game Summary Row */}
               <div
-                className="p-4 flex items-center justify-between cursor-pointer hover:bg-gray-50"
+                className="p-4 flex items-center justify-between cursor-pointer hover:bg-gray-50 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
                 onClick={() => toggleGameExpansion(game.id)}
-                onKeyDown={(e) => e.key === 'Enter' && toggleGameExpansion(game.id)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    toggleGameExpansion(game.id);
+                  }
+                }}
                 tabIndex={0}
                 role="button"
                 aria-expanded={expandedGameId === game.id}

--- a/app/components/PlayerGrid.tsx
+++ b/app/components/PlayerGrid.tsx
@@ -65,11 +65,17 @@ export function PlayerGrid({
             <div
               key={player.id}
               onClick={() => canSelect && handlePlayerClick(player.id)}
-              onKeyDown={(e) => canSelect && (e.key === 'Enter' || e.key === ' ') && handlePlayerClick(player.id)}
+              onKeyDown={(e) => {
+                if (canSelect && (e.key === 'Enter' || e.key === ' ')) {
+                  e.preventDefault();
+                  handlePlayerClick(player.id);
+                }
+              }}
               tabIndex={canSelect ? 0 : -1}
               role="button"
               aria-pressed={isSelected}
-              className={`p-3 border rounded-lg cursor-pointer transition-all ${isSelected
+              aria-disabled={!canSelect}
+              className={`p-3 border rounded-lg cursor-pointer transition-all focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none ${isSelected
                 ? 'border-blue-500 bg-blue-50'
                 : canSelect
                   ? 'border-gray-200 hover:border-gray-300'


### PR DESCRIPTION
### 💡 What
Improved keyboard accessibility for custom buttons (`role="button"`) in `PlayerGrid` and `GameHistory` components.

### 🎯 Why
When elements like `div` are used as buttons (`role="button"`), they often lack default focus outlines and cause the page to scroll when the `Space` key is pressed. These changes provide visual feedback for keyboard users and prevent unintended scrolling.

### 📸 Before/After
(No visual changes for mouse users; keyboard focus ring now appears when navigating via Tab).

### ♿ Accessibility
- Added `focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none` styles to indicate focus.
- Implemented `e.preventDefault()` on `onKeyDown` when the Space key is pressed to prevent page scrolling.
- Added `aria-disabled` attribute to communicate the disabled state of unselectable players in `PlayerGrid` to screen readers.

---
*PR created automatically by Jules for task [14329797271449234988](https://jules.google.com/task/14329797271449234988) started by @kjschaef*