### PR TITLE
🧪 Add unit tests for cn classname utility

### DIFF
--- a/agent-context/graph.json
+++ b/agent-context/graph.json
@@ -782,6 +782,19 @@
       "overrideNotes": []
     },
     {
+      "file": "app/lib/__tests__/utils.test.ts",
+      "type": "app-lib",
+      "tags": [],
+      "imports": [
+        "app/lib/utils.ts"
+      ],
+      "importedBy": [],
+      "related": [
+        "app/lib/utils.ts"
+      ],
+      "overrideNotes": []
+    },
+    {
       "file": "app/lib/constants.ts",
       "type": "app-lib",
       "tags": [],

--- a/agent-context/tests.json
+++ b/agent-context/tests.json
@@ -150,6 +150,13 @@
       "covers": [
         "app/lib/tooltip.ts"
       ]
+    },
+    {
+      "path": "app/lib/__tests__/utils.test.ts",
+      "kind": "app-lib",
+      "covers": [
+        "app/lib/utils.ts"
+      ]
     }
   ],
   "coverageByFile": {
@@ -207,6 +214,9 @@
     ],
     "app/lib/types.ts": [
       "app/lib/__tests__/team-balancer.test.ts"
+    ],
+    "app/lib/utils.ts": [
+      "app/lib/__tests__/utils.test.ts"
     ],
     "app/page.tsx": [
       "__tests__/components/DashboardPage.test.tsx"

--- a/app/lib/__tests__/utils.test.ts
+++ b/app/lib/__tests__/utils.test.ts
@@ -1,0 +1,38 @@
+import { cn } from '../utils';
+
+describe('cn utility', () => {
+  it('merges basic class names', () => {
+    expect(cn('class1', 'class2')).toBe('class1 class2');
+  });
+
+  it('handles conditional classes', () => {
+    expect(cn('class1', false && 'class2', 'class3')).toBe('class1 class3');
+    expect(cn('class1', undefined, null, 'class2')).toBe('class1 class2');
+  });
+
+  it('merges object classes based on truthy values', () => {
+    expect(cn({ class1: true, class2: false, class3: true })).toBe('class1 class3');
+  });
+
+  it('handles arrays of class names', () => {
+    expect(cn(['class1', 'class2'], 'class3')).toBe('class1 class2 class3');
+  });
+
+  it('resolves tailwind class conflicts correctly', () => {
+    // p-4 should override p-2
+    expect(cn('p-2', 'p-4')).toBe('p-4');
+
+    // text-red-500 should override text-blue-500
+    expect(cn('text-blue-500 text-red-500')).toBe('text-red-500');
+
+    // handles complex conflicting combinations
+    expect(cn('px-2 py-1', 'p-4')).toBe('p-4');
+  });
+
+  it('handles empty inputs safely', () => {
+    expect(cn()).toBe('');
+    expect(cn('')).toBe('');
+    expect(cn([])).toBe('');
+    expect(cn({})).toBe('');
+  });
+});


### PR DESCRIPTION
🎯 **What:** The `cn` utility function in `app/lib/utils.ts` was lacking unit test coverage despite being a core utility used throughout the UI components to merge Tailwind classes safely.
📊 **Coverage:** The new tests cover:
- Basic string concatenation
- Conditional and falsy values (e.g., handling boolean short-circuits, undefined, null)
- Objects and arrays parsed via clsx
- Validating proper Tailwind CSS class conflict resolution (via `twMerge`) such as padding and text color overrides
- Safety handling for empty input parameters
✨ **Result:** Provides 100% test coverage for the `cn` utility, guaranteeing that class merging logic safely handles varied data types without throwing errors and correctly resolves CSS specificity before use.

---
*PR created automatically by Jules for task [5513607970460175493](https://jules.google.com/task/5513607970460175493) started by @kjschaef*