### PR TITLE
🎨 Palette: Add aria-labels to Edit and Delete player buttons

### DIFF
--- a/app/components/PlayerCards.tsx
+++ b/app/components/PlayerCards.tsx
@@ -107,6 +107,7 @@ function PlayerCard({ player, onEdit, onDelete, isInactive = false, championship
               className="p-1 hover:bg-white/80 rounded transition-colors shadow-sm"
               onClick={() => onEdit(player)}
               title="Edit player"
+              aria-label="Edit player"
             >
               <Edit className="h-3.5 w-3.5 text-gray-600" />
             </button>
@@ -115,6 +116,7 @@ function PlayerCard({ player, onEdit, onDelete, isInactive = false, championship
                 <button
                   className="p-1 hover:bg-red-50 rounded transition-colors shadow-sm"
                   title="Delete player"
+                  aria-label="Delete player"
                 >
                   <Trash2 className="h-3.5 w-3.5 text-gray-600 hover:text-red-600" />
                 </button>


### PR DESCRIPTION
💡 **What:** Added `aria-label` attributes to the "Edit player" and "Delete player" buttons within the `PlayerCards` component.
🎯 **Why:** To improve accessibility for screen readers. Icon-only buttons must have accessible names describing their functionality.
📸 **Before/After:** Not applicable (purely an accessibility markup change; no visual differences).
♿ **Accessibility:** Users navigating with screen readers will now hear "Edit player" and "Delete player" rather than just identifying a generic, unlabeled button.

---
*PR created automatically by Jules for task [7249202321242345013](https://jules.google.com/task/7249202321242345013) started by @kjschaef*