### PR TITLE
🎨 Palette: Add focus states to buttons in PlayerCard and SeasonSelector

### DIFF
--- a/app/components/PlayerCard.tsx
+++ b/app/components/PlayerCard.tsx
@@ -60,7 +60,7 @@ export function PlayerCard({ player, onEdit, onDelete }: PlayerCardProps) {
           <div className="flex space-x-1">
             <button
               onClick={() => onEdit ? onEdit(player) : setShowEditDialog(true)}
-              className="text-gray-500 hover:text-gray-700 p-1"
+              className="text-gray-500 hover:text-gray-700 p-1 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
               aria-label="Edit player"
             >
               <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -73,7 +73,7 @@ export function PlayerCard({ player, onEdit, onDelete }: PlayerCardProps) {
                   onDelete?.(player.id);
                 }
               }}
-              className="text-red-500 hover:text-red-700 p-1"
+              className="text-red-500 hover:text-red-700 p-1 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
               aria-label="Delete player"
             >
               <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -115,13 +115,13 @@ export function PlayerCard({ player, onEdit, onDelete }: PlayerCardProps) {
                   <button
                     type="button"
                     onClick={() => setShowEditDialog(false)}
-                    className="w-full py-2 px-4 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50"
+                    className="w-full py-2 px-4 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                   >
                     Cancel
                   </button>
                   <button
                     type="submit"
-                    className="w-full py-2 px-4 bg-blue-600 text-white rounded-md hover:bg-blue-700"
+                    className="w-full py-2 px-4 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
                   >
                     Update
                   </button>

--- a/app/components/SeasonSelector.tsx
+++ b/app/components/SeasonSelector.tsx
@@ -20,13 +20,13 @@ export function SeasonSelector({ seasons = [], currentSeason = 'current', onSeas
     <div className="flex items-center space-x-4">
       <div className="flex items-center space-x-2">
         <button
-          className={selected === 'current' ? 'bg-blue-600 text-white px-3 py-1 rounded' : 'bg-gray-100 text-gray-700 px-3 py-1 rounded'}
+          className={selected === 'current' ? 'bg-blue-600 text-white px-3 py-1 rounded transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1' : 'bg-gray-100 text-gray-700 hover:bg-gray-200 px-3 py-1 rounded transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1'}
           onClick={() => onSeasonChange('current')}
         >
           Current Season
         </button>
         <button
-          className={selected === 'lifetime' ? 'bg-blue-600 text-white px-3 py-1 rounded' : 'bg-gray-100 text-gray-700 px-3 py-1 rounded'}
+          className={selected === 'lifetime' ? 'bg-blue-600 text-white px-3 py-1 rounded transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1' : 'bg-gray-100 text-gray-700 hover:bg-gray-200 px-3 py-1 rounded transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1'}
           onClick={() => onSeasonChange('lifetime')}
         >
           Lifetime Stats
@@ -34,7 +34,7 @@ export function SeasonSelector({ seasons = [], currentSeason = 'current', onSeas
       </div>
 
       {historical.length > 0 && (
-        <select aria-label="Season" role="combobox" value={selected} onChange={e => onSeasonChange(e.target.value)} className="border px-3 py-2 rounded h-10 text-sm">
+        <select aria-label="Season" role="combobox" value={selected} onChange={e => onSeasonChange(e.target.value)} className="border px-3 py-2 rounded h-10 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500">
           <option value="current">{active ? active.name : 'Current Season'}</option>
           {historical.map(s => (
             <option key={s.id} value={String(s.id)}>{s.name}</option>


### PR DESCRIPTION
💡 **What**: Added `focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none` classes to buttons in `PlayerCard.tsx` and `SeasonSelector.tsx`. Also added `transition-colors` and `hover:bg-gray-200` to the `<button>` and `focus-visible` to `<select>` in `SeasonSelector.tsx`.

🎯 **Why**: To improve keyboard accessibility. Interactive elements should have clear focus indicators when navigated via keyboard.

📸 **Before/After**: Keyboard navigation previously showed no outline or ring on the edit/delete buttons in player cards or the buttons in the season selector. Now they show a clear blue/red ring.

♿ **Accessibility**: Keyboard navigation is explicitly supported through standard Tailwind `focus-visible` classes.

---
*PR created automatically by Jules for task [11345444889843704603](https://jules.google.com/task/11345444889843704603) started by @kjschaef*