### PR TITLE
Integrate 'Use This Matchup' button with match recording

### DIFF
--- a/app/components/ChatBot.tsx
+++ b/app/components/ChatBot.tsx
@@ -549,13 +549,17 @@ export function ChatBot({ onUseMatchup, onRecordMatch, isOpen: controlledIsOpen,
           className="w-full"
           variant="outline"
           onClick={() => {
+            const teamOneIds = data.teamOne.map(player => player.id);
+            const teamTwoIds = data.teamTwo.map(player => player.id);
+
             if (onUseMatchup) {
-              const teamOneIds = data.teamOne.map(player => player.id);
-              const teamTwoIds = data.teamTwo.map(player => player.id);
               setIsOpen(false); // Close the chatbot dialog
               onUseMatchup(teamOneIds, teamTwoIds);
+            } else if (onRecordMatch) {
+              setIsOpen(false); // Close the chatbot dialog
+              onRecordMatch(teamOneIds, teamTwoIds, 0, 0);
             } else {
-              // TODO: Integrate with match recording
+              // Fallback alert if neither is provided
               alert(`Team matchup ${index + 1} will be integrated with match recording in the next phase!`);
             }
           }}


### PR DESCRIPTION
The 'Use This Matchup' button in the ChatBot's `TeamSuggestionCard` now initiates the match recording process if the `onUseMatchup` prop is missing. It does this by calling the `onRecordMatch` prop (if available) with the mapped player IDs from the suggested teams and setting both teams' wins to 0. This provides a seamless transition from team suggestion to recording a new match.

I've manually verified the logic in `app/components/ChatBot.tsx` and confirmed it aligns with the application's patterns seen in `app/page.tsx`.

Note: Due to environment limitations (missing `node_modules` and registry access), I was unable to run automated tests or the development server for visual verification. However, the code was reviewed and approved for correctness.

---
*PR created automatically by Jules for task [12250081848623385810](https://jules.google.com/task/12250081848623385810) started by @kjschaef*