### PR TITLE
🧹 Code Health: Remove unused Trophy import in PlayerCards

### DIFF
--- a/app/components/PlayerCards.tsx
+++ b/app/components/PlayerCards.tsx
@@ -18,7 +18,7 @@ import {
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { Label } from "./ui/label";
-import { Edit, Trash2, TrendingUp, Calendar, Trophy } from "lucide-react";
+import { Edit, Trash2, TrendingUp, Calendar } from "lucide-react";
 import { useSeasonChampions } from "../hooks/useSeasonChampions";
 import { AdminLoginModal } from "./AdminLoginModal";
 


### PR DESCRIPTION
🎯 **What:** Removed the unused `Trophy` import from `lucide-react` in `app/components/PlayerCards.tsx`.
💡 **Why:** Improves code maintainability and readability by removing dead code.
✅ **Verification:** Confirmed with `grep` that `Trophy` is no longer referenced anywhere in the file.
✨ **Result:** Cleaner code in `PlayerCards.tsx`.

---
*PR created automatically by Jules for task [4446725442486693161](https://jules.google.com/task/4446725442486693161) started by @kjschaef*