### PR TITLE
🛡️ Shield: Fix React Testing Library act() warnings in SignupsPage.test.tsx

### DIFF
--- a/.jules/shield.md
+++ b/.jules/shield.md
@@ -1,0 +1,3 @@
+## 2025-05-18 - Fix React Testing Library "act()" warnings
+**Learning:** When a component fetches data inside a useEffect and sets state asynchronously upon mount (like `SignupsPage`), wrapping the initial `render()` call in `await act(async () => { render(...) })` ensures all state updates from the mocked `fetch` resolve within the React batch before assertions run. This prevents the "update to X inside a test was not wrapped in act(...)" warning. Similarly, interactive events that trigger async state updates should be wrapped in `await act(async () => { fireEvent(...) })`.
+**Action:** Identify and fix `act()` warnings in other component tests that mount async components by replacing `render(<Component />)` with `await act(async () => { render(<Component />); })`.

--- a/__tests__/components/SignupsPage.test.tsx
+++ b/__tests__/components/SignupsPage.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import SignupsPage from '@/app/signups/page';
 
@@ -92,15 +92,32 @@ describe('SignupsPage', () => {
   });
 
   it('loads the open signup state and submits a signup for the selected player', async () => {
-    render(<SignupsPage />);
+    await act(async () => {
+      render(<SignupsPage />);
+    });
 
+    // Use findByText to wait for the loading state to complete and the component to fully render
     expect(await screen.findByText('Weekly Signups')).toBeInTheDocument();
     expect(await screen.findByText('Monday, January 19th')).toBeInTheDocument();
-    expect(screen.queryByText('Tuesday, January 20th')).not.toBeInTheDocument();
+
+    // Use waitFor for non-existence checks to ensure updates have settled
+    await waitFor(() => {
+      expect(screen.queryByText('Tuesday, January 20th')).not.toBeInTheDocument();
+    });
     expect(screen.getByText('Thursday, January 22nd')).toBeInTheDocument();
 
-    fireEvent.change(screen.getByRole('combobox'), { target: { value: '1' } });
-    fireEvent.click(screen.getAllByText('Sign Up')[0]);
+    // Verify select is loaded
+    const combobox = await screen.findByRole('combobox');
+
+    await act(async () => {
+      fireEvent.change(combobox, { target: { value: '1' } });
+    });
+
+    // Find the signup button correctly after data is loaded
+    const signUpButtons = await screen.findAllByText('Sign Up');
+    await act(async () => {
+      fireEvent.click(signUpButtons[0]);
+    });
 
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith(
@@ -111,16 +128,24 @@ describe('SignupsPage', () => {
   });
 
   it('renders existing signup entries with remove controls', async () => {
-    render(<SignupsPage />);
+    await act(async () => {
+      render(<SignupsPage />);
+    });
 
-    expect(await screen.findByTitle('Remove player')).toBeInTheDocument();
-    expect(screen.getAllByTitle('Remove player')).toHaveLength(1);
-    expect(screen.getByText('1.')).toBeInTheDocument();
+    // Wait for the specific element to appear to signify rendering is complete
+    const removePlayerButtons = await screen.findAllByTitle('Remove player');
+    expect(removePlayerButtons).toHaveLength(1);
+
+    // Use findByText for assertion to ensure it's fully rendered
+    expect(await screen.findByText('1.')).toBeInTheDocument();
   });
 
   it('renders unavailable players with remove controls', async () => {
-    render(<SignupsPage />);
+    await act(async () => {
+      render(<SignupsPage />);
+    });
 
+    // Using findByTitle waits for the fetch requests to resolve and state to update
     expect(await screen.findByTitle('Remove unavailable player')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
💡 What: Refactored `__tests__/components/SignupsPage.test.tsx` to fix React Testing Library "act()" warnings related to asynchronous state updates during component mount and interaction.

🎯 Why: To improve the test suite's reliability and output clarity. The tests were previously causing `console.error` noise because mocked `fetch` promises resolved and updated state after the initial synchronous rendering or clicking actions. By utilizing asynchronous `act` wrappers over interactive calls (or the more idiomatically correct approach of `findBy` methods to await rendering and element availability, which we've applied here), we ensure assertions run deterministically once state has fully settled.

📊 Impact: Reduces test noise by silencing console errors without sacrificing test integrity. Makes debugging failing UI components easier in CI environments.

🔬 Measurement: Verify locally by running `pnpm test -- __tests__/components/SignupsPage.test.tsx` and observe a clean pass without `console.error` act warnings.

---
*PR created automatically by Jules for task [13309708570925630382](https://jules.google.com/task/13309708570925630382) started by @kjschaef*