### PR TITLE
🎨 Palette: Add focus states and aria-pressed to PlayerSelector

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -24,3 +24,7 @@
 
 **Learning:** Replacing custom `<div role="button">` containers with native semantic `<button>` elements is highly effective for accessibility. It prevents nested interactive element issues (e.g., `<button>` inside `<div role="button">`) and ensures native keyboard support without manual `tabIndex` or `onKeyDown` listeners.
 **Action:** When refactoring interactive containers, use a native `<button>` and apply `w-full text-left` to preserve layout. Convert any previously clickable inner elements (like toggle icons) to non-interactive decorative elements (e.g., `<span aria-hidden="true">`).
+
+## 2024-05-21 - Toggle Button Accessibility
+**Learning:** Components acting as selectable or toggleable options (like player selection buttons) often map visual cues (e.g. background color changes) to indicate selection but fail to communicate this state to screen readers.
+**Action:** When implementing toggle buttons or selectable chips, always include `aria-pressed={boolean}`. This explicitly tells assistive technologies whether the button is currently in a pressed (selected) or unpressed state. Also ensure they have keyboard focus states (`focus-visible:ring`).

--- a/app/components/PlayerSelector.tsx
+++ b/app/components/PlayerSelector.tsx
@@ -31,9 +31,10 @@ export function PlayerSelector({
             <button
               key={player.id}
               type="button"
+              aria-pressed={isSelected}
               onClick={() => onSelect(player.id)}
               disabled={isDisabled}
-              className={`px-3 py-1 rounded text-sm ${
+              className={`px-3 py-1 rounded text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
                 isSelected
                   ? 'bg-blue-600 text-white'
                   : isDisabled

--- a/app/components/PlayerSelectorDialog.tsx
+++ b/app/components/PlayerSelectorDialog.tsx
@@ -59,9 +59,10 @@ export function PlayerSelectorDialog({
                   <button
                     key={player.id}
                     type="button"
+                    aria-pressed={isSelected}
                     onClick={() => onTogglePlayer(player.id)}
                     className={`
-                      px-3 py-2 rounded-lg text-sm font-medium transition-colors
+                      px-3 py-2 rounded-lg text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500
                       ${isSelected
                         ? 'bg-blue-500 text-white'
                         : 'bg-gray-100 text-gray-900 hover:bg-gray-200'


### PR DESCRIPTION
💡 What: Added `focus-visible:ring-2`, `focus-visible:outline-none`, and `focus-visible:ring-blue-500` classes to player selection toggle buttons in `PlayerSelector.tsx` and `PlayerSelectorDialog.tsx`. Also added the `aria-pressed={isSelected}` attribute to communicate their state to screen readers.
🎯 Why: To ensure keyboard users can easily identify which player button they are focused on, and to explicitly communicate the selected state of the player toggle buttons to assistive technologies.
📸 Before/After: Before, buttons did not visibly highlight when tabbed into, and screen readers only read them as standard buttons. After, they have a clear blue focus ring and use `aria-pressed` semantics.
♿ Accessibility: Improves keyboard navigation with clear focus indicators and enhances screen reader support for toggle states via the `aria-pressed` ARIA attribute.

---
*PR created automatically by Jules for task [14251732124450550931](https://jules.google.com/task/14251732124450550931) started by @kjschaef*