### PR TITLE
🎨 Palette: Improve accessibility of player selection chips

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2024-05-21 - Toggle Button Accessibility
 **Learning:** Components acting as selectable or toggleable options (like player selection buttons) often map visual cues (e.g. background color changes) to indicate selection but fail to communicate this state to screen readers.
 **Action:** When implementing toggle buttons or selectable chips, always include `aria-pressed={boolean}`. This explicitly tells assistive technologies whether the button is currently in a pressed (selected) or unpressed state. Also ensure they have keyboard focus states (`focus-visible:ring`).
+
+## 2024-05-22 - Selection Buttons and aria-pressed
+**Learning:** Even when buttons exist within specialized contexts (like a list of `players`), if they act as a toggle or selectable item, they *must* declare `aria-pressed` explicitly, otherwise screen readers cannot determine if the user has selected them.
+**Action:** Always add `aria-pressed={boolean}` and `focus-visible:ring-2` to buttons acting as interactive selection items in grids or lists.

--- a/app/components/RecordMatchModal.tsx
+++ b/app/components/RecordMatchModal.tsx
@@ -64,10 +64,11 @@ function PlayerGrid({ players, selectedPlayers, onPlayerToggle, maxPlayers, titl
             <button
               key={player.id}
               type="button"
+              aria-pressed={isSelected}
               onClick={() => handlePlayerClick(player.id)}
               disabled={!canSelect}
               className={`
-                px-3 py-2 rounded-lg text-sm font-medium transition-colors
+                px-3 py-2 rounded-lg text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1
                 ${isSelected 
                   ? 'bg-blue-500 text-white' 
                   : isDisabled


### PR DESCRIPTION
💡 **What**:
Added `aria-pressed={isSelected}` and explicit focus styles (`focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 focus-visible:outline-none`) to the inner player selection buttons in the `PlayerGrid` component used within the `RecordMatchModal`.

🎯 **Why**:
When using a screen reader to navigate the grid of players, the items lacked standard toggle feedback (meaning they didn't report whether they were toggled "on" or "off"). Furthermore, when navigating via keyboard (Tab), the browser's default focus ring was heavily dependent on user agent styling and didn't clearly pop out against the application's UI, making it hard to see which player chip was focused. 

📸 **Before/After**:
*   *Before*: Screen readers announced simply "Button, Alice". Tabbing between chips produced a subtle outline depending on browser. 
*   *After*: Screen readers announce "Button, Alice, pressed" (or unpressed). Focused chips now feature a bright blue focus ring clearly defining the selection boundary.

♿ **Accessibility**:
*   Implemented `aria-pressed` state tracking.
*   Added high-contrast explicit `focus-visible` focus outlines.

---
*PR created automatically by Jules for task [2678698089383180888](https://jules.google.com/task/2678698089383180888) started by @kjschaef*