### PR TITLE
🛡️ Shield: add unit tests for player filtering threshold

### DIFF
--- a/agent-context/graph.json
+++ b/agent-context/graph.json
@@ -733,6 +733,23 @@
       "overrideNotes": []
     },
     {
+      "file": "app/lib/__tests__/playerFiltering.test.ts",
+      "type": "app-lib",
+      "tags": [
+        "players"
+      ],
+      "imports": [
+        "app/lib/constants.ts",
+        "app/lib/playerFiltering.ts"
+      ],
+      "importedBy": [],
+      "related": [
+        "app/lib/constants.ts",
+        "app/lib/playerFiltering.ts"
+      ],
+      "overrideNotes": []
+    },
+    {
       "file": "app/lib/__tests__/signups.test.ts",
       "type": "app-lib",
       "tags": [],

--- a/agent-context/tests.json
+++ b/agent-context/tests.json
@@ -133,6 +133,14 @@
       ]
     },
     {
+      "path": "app/lib/__tests__/playerFiltering.test.ts",
+      "kind": "app-lib",
+      "covers": [
+        "app/lib/constants.ts",
+        "app/lib/playerFiltering.ts"
+      ]
+    },
+    {
       "path": "app/lib/__tests__/signups.test.ts",
       "kind": "app-lib",
       "covers": [
@@ -217,6 +225,12 @@
     ],
     "app/games/page.tsx": [
       "__tests__/components/GamesPage.test.tsx"
+    ],
+    "app/lib/constants.ts": [
+      "app/lib/__tests__/playerFiltering.test.ts"
+    ],
+    "app/lib/playerFiltering.ts": [
+      "app/lib/__tests__/playerFiltering.test.ts"
     ],
     "app/lib/signups.ts": [
       "app/lib/__tests__/signups.test.ts"

--- a/app/lib/__tests__/playerFiltering.test.ts
+++ b/app/lib/__tests__/playerFiltering.test.ts
@@ -1,0 +1,44 @@
+import { getPlayerThreshold } from '../playerFiltering';
+import { MINIMUM_GAMES_THRESHOLD } from '../constants';
+
+describe('getPlayerThreshold', () => {
+    it('returns 1 if showAllPlayers is true, regardless of players array', () => {
+        expect(getPlayerThreshold([{ record: { totalGames: 100 } }], true)).toBe(1);
+    });
+
+    it('returns 1 if players array is empty', () => {
+        expect(getPlayerThreshold([], false)).toBe(1);
+    });
+
+    it('returns 1 if players is not an array', () => {
+        // @ts-expect-error - testing invalid input
+        expect(getPlayerThreshold(null, false)).toBe(1);
+        // @ts-expect-error - testing invalid input
+        expect(getPlayerThreshold(undefined, false)).toBe(1);
+    });
+
+    it('returns 1 if no players meet the MINIMUM_GAMES_THRESHOLD', () => {
+        const players = [
+            { record: { totalGames: MINIMUM_GAMES_THRESHOLD - 1 } },
+            { record: { totalGames: 0 } },
+            {} // testing missing record
+        ];
+        expect(getPlayerThreshold(players, false)).toBe(1);
+    });
+
+    it('returns MINIMUM_GAMES_THRESHOLD if at least one player meets the threshold', () => {
+        const players = [
+            { record: { totalGames: MINIMUM_GAMES_THRESHOLD - 1 } },
+            { record: { totalGames: MINIMUM_GAMES_THRESHOLD } },
+        ];
+        expect(getPlayerThreshold(players, false)).toBe(MINIMUM_GAMES_THRESHOLD);
+    });
+
+    it('returns MINIMUM_GAMES_THRESHOLD if multiple players meet the threshold', () => {
+        const players = [
+            { record: { totalGames: MINIMUM_GAMES_THRESHOLD + 10 } },
+            { record: { totalGames: MINIMUM_GAMES_THRESHOLD + 20 } },
+        ];
+        expect(getPlayerThreshold(players, false)).toBe(MINIMUM_GAMES_THRESHOLD);
+    });
+});

--- a/update_shield_journal.py
+++ b/update_shield_journal.py
@@ -1,0 +1,12 @@
+import re
+
+journal_file = '.jules/shield.md'
+try:
+    with open(journal_file, 'r') as f:
+        content = f.read()
+except FileNotFoundError:
+    content = ""
+
+# Only add if it's a truly critical testing learning. This task was standard unit testing.
+# No novel learning to record for Next.js/React/Playwright edge cases today.
+print("No new edge case learnings to add to shield.md")


### PR DESCRIPTION
💡 What: Added unit tests for the `getPlayerThreshold` function in `app/lib/playerFiltering.ts`.
🎯 Why: This critical utility function determines player visibility thresholds based on games played, but previously lacked unit test coverage. Testing it ensures edge cases (empty arrays, missing properties, varying thresholds) are handled correctly and prevents regressions.
📊 Impact: Increases unit test coverage for the `lib/` directory and protects against regressions in threshold logic.
🔬 Measurement: Run locally via `pnpm test app/lib/__tests__/playerFiltering.test.ts`.

---
*PR created automatically by Jules for task [14064860584116014878](https://jules.google.com/task/14064860584116014878) started by @kjschaef*