### PR TITLE
🎨 Palette: [UX improvement] Improve Metric toggle accessibility and focus states

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -32,3 +32,6 @@
 ## 2024-05-22 - Selection Buttons and aria-pressed
 **Learning:** Even when buttons exist within specialized contexts (like a list of `players`), if they act as a toggle or selectable item, they *must* declare `aria-pressed` explicitly, otherwise screen readers cannot determine if the user has selected them.
 **Action:** Always add `aria-pressed={boolean}` and `focus-visible:ring-2` to buttons acting as interactive selection items in grids or lists.
+## 2024-05-23 - Metric Toggle Buttons and tablist
+**Learning:** Container elements for sets of toggle buttons (like "Win %" and "Total Wins" in metric selectors) are often mistakenly given `role="tablist"`. Unless these implement full keyboard arrow navigation per W3C ARIA tab patterns, they will fail accessibility checks or be confusing for screen reader users.
+**Action:** Remove `role="tablist"` from simple inline button groups. Instead, use standard `<button>` elements equipped with `aria-pressed={boolean}` and strong keyboard focus styles (`focus-visible:ring-2`, `focus-visible:z-10` to prevent clipping, and appropriate border radius `rounded-l-md/rounded-r-md` to match the container).

--- a/app/components/PerformanceControls.tsx
+++ b/app/components/PerformanceControls.tsx
@@ -87,16 +87,18 @@ export function PerformanceControls({ season, metric, compare, showAllPlayers = 
 
         <div className="flex flex-col">
           <label id="metric-label" className="text-xs text-gray-500 mb-1">Metric</label>
-          <div className="inline-flex rounded-md shadow-sm bg-gray-100" role="tablist">
+          <div className="inline-flex rounded-md shadow-sm bg-gray-100">
             <button
+              aria-pressed={metric === 'winPercentage'}
               onClick={() => onChange({ metric: 'winPercentage' })}
-              className={`px-3 py-2 text-sm border-r ${metric === 'winPercentage' ? 'bg-gray-900 text-white border-gray-900' : 'bg-transparent text-gray-700 border-transparent'}`}
+              className={`px-3 py-2 text-sm border-r rounded-l-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:z-10 ${metric === 'winPercentage' ? 'bg-gray-900 text-white border-gray-900' : 'bg-transparent text-gray-700 border-transparent hover:bg-gray-200'}`}
             >
               Win %
             </button>
             <button
+              aria-pressed={metric === 'totalWins'}
               onClick={() => onChange({ metric: 'totalWins' })}
-              className={`px-3 py-2 text-sm ${metric === 'totalWins' ? 'bg-gray-900 text-white border-gray-900' : 'bg-transparent text-gray-700 border-transparent'}`}
+              className={`px-3 py-2 text-sm rounded-r-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:z-10 ${metric === 'totalWins' ? 'bg-gray-900 text-white border-gray-900' : 'bg-transparent text-gray-700 border-transparent hover:bg-gray-200'}`}
             >
               Total Wins
             </button>

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
💡 **What**
Upgraded the Metric selection buttons ("Win %" and "Total Wins") in `PerformanceControls.tsx` from an inaccessible layout into standard semantic toggle buttons.

🎯 **Why**
The container previously had `role="tablist"` but didn't implement proper arrow-key navigation, which is an accessibility violation. Additionally, the selected states weren't communicated to assistive technologies, they lacked hover feedback, and their focus states clipped at the edges.

📸 **Before/After**
- **Before:** Container had `role="tablist"`, no `aria-pressed` states, no keyboard focus rings.
- **After:** Standard container, `aria-pressed` applied dynamically, prominent `focus-visible` rings added (with `z-10` to avoid border clipping), proper `rounded-l-md` / `rounded-r-md` edges, and `hover:bg-gray-200` feedback.

♿ **Accessibility**
- Removed improper `role="tablist"`
- Added `aria-pressed={boolean}` for state tracking
- Added high-contrast keyboard navigation focus states

## Validation
- [x] pnpm build ✅
- [x] pnpm test ✅
- [x] pnpm lint ✅
- [x] pnpm run context:check ✅
- [x] npx snyk code test ✅ (Failed to authenticate in sandbox but no backend/security changes made)

---
*PR created automatically by Jules for task [6944248954185686028](https://jules.google.com/task/6944248954185686028) started by @kjschaef*