### PR TITLE
🎨 Palette: [UX improvement] Fix tablist a11y for metric buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -32,3 +32,7 @@
 ## 2024-05-22 - Selection Buttons and aria-pressed
 **Learning:** Even when buttons exist within specialized contexts (like a list of `players`), if they act as a toggle or selectable item, they *must* declare `aria-pressed` explicitly, otherwise screen readers cannot determine if the user has selected them.
 **Action:** Always add `aria-pressed={boolean}` and `focus-visible:ring-2` to buttons acting as interactive selection items in grids or lists.
+
+## 2024-05-23 - Tablist vs Standard Buttons
+**Learning:** Using `role="tablist"` on a container requires implementing full arrow-key keyboard navigation to be accessible. For simple visual toggle buttons (like metric selectors), using standard `<button>` elements with `aria-pressed` is much more accessible and handles keyboard interactions natively without custom JS.
+**Action:** When implementing toggle buttons (e.g., selection items or metric tabs), avoid `role="tablist"` unless implementing full keyboard navigation. Instead, use standard `<button>` elements with `aria-pressed={boolean}` and proper focus styles (e.g., `focus-visible:ring-2 focus-visible:outline-none`), adding `focus-visible:z-10` to prevent adjacent button borders from clipping the focus ring, and ensure outer corners (e.g., `rounded-l-md` and `rounded-r-md`) are rounded to match the container shape.

--- a/app/components/PerformanceControls.tsx
+++ b/app/components/PerformanceControls.tsx
@@ -87,16 +87,18 @@ export function PerformanceControls({ season, metric, compare, showAllPlayers = 
 
         <div className="flex flex-col">
           <label id="metric-label" className="text-xs text-gray-500 mb-1">Metric</label>
-          <div className="inline-flex rounded-md shadow-sm bg-gray-100" role="tablist">
+          <div className="inline-flex rounded-md shadow-sm bg-gray-100">
             <button
+              aria-pressed={metric === 'winPercentage'}
               onClick={() => onChange({ metric: 'winPercentage' })}
-              className={`px-3 py-2 text-sm border-r ${metric === 'winPercentage' ? 'bg-gray-900 text-white border-gray-900' : 'bg-transparent text-gray-700 border-transparent'}`}
+              className={`px-3 py-2 text-sm border-r rounded-l-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:z-10 ${metric === 'winPercentage' ? 'bg-gray-900 text-white border-gray-900' : 'bg-transparent text-gray-700 border-transparent'}`}
             >
               Win %
             </button>
             <button
+              aria-pressed={metric === 'totalWins'}
               onClick={() => onChange({ metric: 'totalWins' })}
-              className={`px-3 py-2 text-sm ${metric === 'totalWins' ? 'bg-gray-900 text-white border-gray-900' : 'bg-transparent text-gray-700 border-transparent'}`}
+              className={`px-3 py-2 text-sm rounded-r-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:z-10 ${metric === 'totalWins' ? 'bg-gray-900 text-white border-gray-900' : 'bg-transparent text-gray-700 border-transparent'}`}
             >
               Total Wins
             </button>
@@ -161,7 +163,7 @@ export function PerformanceControls({ season, metric, compare, showAllPlayers = 
 
         <div className="ml-auto flex items-center">
           <button
-            className="text-sm text-gray-600 hover:text-gray-900"
+            className="text-sm text-gray-600 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-900 rounded px-2 py-1"
             onClick={() => onChange({ action: 'reset' })}
           >
             Reset

--- a/app/components/PerformanceTrend.tsx
+++ b/app/components/PerformanceTrend.tsx
@@ -357,7 +357,7 @@ export function PerformanceTrend({ isExporting: _isExporting = false, season: in
                 <button
                   type="button"
                   onClick={resetZoom}
-                  className="rounded border border-gray-300 px-3 py-1 text-sm font-medium text-gray-700 transition hover:bg-gray-50"
+                  className="rounded border border-gray-300 px-3 py-1 text-sm font-medium text-gray-700 transition hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                 >
                   Reset zoom
                 </button>


### PR DESCRIPTION
## What changed
Fixed accessibility issues in the PerformanceControls component where a `role="tablist"` was incorrectly used for a simple toggle button group without full keyboard arrow navigation logic. It was replaced with `aria-pressed` on standard buttons. Focus indicators (`focus-visible:ring-2`) and proper `z-10` behaviors were added to those toggles, as well as the adjacent "Reset" and "Reset zoom" buttons.

## Why
Using `role="tablist"` on a container requires the implementation of custom JavaScript to handle arrow key navigation between tabs. Since this was just a visual toggle between two metrics, native button semantics with `aria-pressed` correctly announce the state to screen readers while natively supporting `Tab` and `Enter`/`Space` without additional JS. Proper focus styles make the application usable for keyboard-only users.

## Validation
- [x] pnpm build ✅
- [x] pnpm test ✅
- [x] pnpm lint ✅
- [x] pnpm run context:check ✅
- [x] npx snyk code test ✅ (no new first-party code introduced, just HTML attributes and CSS classes)

---
*PR created automatically by Jules for task [17026330287133499782](https://jules.google.com/task/17026330287133499782) started by @kjschaef*