### PR TITLE
🎨 Palette: [UX improvement] Fix metric toggle accessibility in PerformanceControls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -32,3 +32,7 @@
 ## 2024-05-22 - Selection Buttons and aria-pressed
 **Learning:** Even when buttons exist within specialized contexts (like a list of `players`), if they act as a toggle or selectable item, they *must* declare `aria-pressed` explicitly, otherwise screen readers cannot determine if the user has selected them.
 **Action:** Always add `aria-pressed={boolean}` and `focus-visible:ring-2` to buttons acting as interactive selection items in grids or lists.
+
+## 2024-05-23 - Tablist vs Toggle Buttons
+**Learning:** Using `role="tablist"` on a container of metric toggles is inappropriate unless full keyboard navigation (left/right arrow keys to switch tabs) is implemented. For simple `<button>` groups where each button changes a metric or view on click, they function as independent toggle buttons.
+**Action:** Remove `role="tablist"` from containers of toggle options. Instead, treat them as standard buttons. Apply `aria-pressed={boolean}` to correctly announce the selected state to screen readers, ensure they use the correct focus indicators (`focus-visible:ring`), and adjust adjacent border radii (e.g. `rounded-l-md`, `rounded-r-md`) and z-indices (`focus-visible:z-10`) so the focus ring isn't clipped by neighboring buttons.

--- a/app/components/PerformanceControls.tsx
+++ b/app/components/PerformanceControls.tsx
@@ -87,16 +87,18 @@ export function PerformanceControls({ season, metric, compare, showAllPlayers = 
 
         <div className="flex flex-col">
           <label id="metric-label" className="text-xs text-gray-500 mb-1">Metric</label>
-          <div className="inline-flex rounded-md shadow-sm bg-gray-100" role="tablist">
+          <div className="inline-flex rounded-md shadow-sm bg-gray-100">
             <button
+              aria-pressed={metric === 'winPercentage'}
               onClick={() => onChange({ metric: 'winPercentage' })}
-              className={`px-3 py-2 text-sm border-r ${metric === 'winPercentage' ? 'bg-gray-900 text-white border-gray-900' : 'bg-transparent text-gray-700 border-transparent'}`}
+              className={`rounded-l-md px-3 py-2 text-sm border-r focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:z-10 ${metric === 'winPercentage' ? 'bg-gray-900 text-white border-gray-900' : 'bg-transparent text-gray-700 border-transparent hover:bg-gray-200 transition-colors'}`}
             >
               Win %
             </button>
             <button
+              aria-pressed={metric === 'totalWins'}
               onClick={() => onChange({ metric: 'totalWins' })}
-              className={`px-3 py-2 text-sm ${metric === 'totalWins' ? 'bg-gray-900 text-white border-gray-900' : 'bg-transparent text-gray-700 border-transparent'}`}
+              className={`rounded-r-md px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:z-10 ${metric === 'totalWins' ? 'bg-gray-900 text-white border-gray-900' : 'bg-transparent text-gray-700 border-transparent hover:bg-gray-200 transition-colors'}`}
             >
               Total Wins
             </button>

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
💡 **What:** 
Replaced an invalid `role="tablist"` container with standard `<button>` toggle items in the `PerformanceControls` component. Added dynamic `aria-pressed` states and enhanced `focus-visible` styling (`z-10` and matched corner radiuses).

🎯 **Why:** 
The `<div role="tablist">` pattern requires complex keyboard implementations (arrow key left/right switching). Without it, screen readers report broken tabs. Converting these to independent `<button aria-pressed="true/false">` elements correctly announces the active metric. The updated focus styles ensure keyboard users see clear focus rings without adjacent button borders overlapping.

📸 **Before/After:** 
(See included Playwright screenshot demonstrating the corrected focus states).

♿ **Accessibility:** 
- Fixes screen-reader announcements of selected state via `aria-pressed`.
- Enhances keyboard navigation clarity by fixing overlapped focus indicators.

## Validation
- [x] pnpm build ✅
- [x] pnpm test ✅
- [x] pnpm lint ✅
- [x] pnpm run context:check ✅
- [x] npx snyk code test ✅ (or: no new first-party code introduced)

---
*PR created automatically by Jules for task [12263477042979476894](https://jules.google.com/task/12263477042979476894) started by @kjschaef*