### PR TITLE
🛡️ Shield: Add unit tests for AdminLoginModal component

### DIFF
--- a/__tests__/components/AdminLoginModal.test.tsx
+++ b/__tests__/components/AdminLoginModal.test.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { AdminLoginModal } from '@/app/components/AdminLoginModal';
+
+describe('AdminLoginModal', () => {
+  const mockOnClose = jest.fn();
+  const mockOnSuccess = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn() as jest.Mock;
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('does not render when isOpen is false', () => {
+    render(<AdminLoginModal isOpen={false} onClose={mockOnClose} onSuccess={mockOnSuccess} />);
+    expect(screen.queryByText('Admin Authentication Required')).not.toBeInTheDocument();
+  });
+
+  it('renders correctly when isOpen is true', () => {
+    render(<AdminLoginModal isOpen={true} onClose={mockOnClose} onSuccess={mockOnSuccess} />);
+    expect(screen.getByText('Admin Authentication Required')).toBeInTheDocument();
+    expect(screen.getByLabelText('Admin Password')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Close modal' })).toBeInTheDocument();
+  });
+
+  it('calls onClose when Cancel button is clicked', () => {
+    render(<AdminLoginModal isOpen={true} onClose={mockOnClose} onSuccess={mockOnSuccess} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when X icon is clicked', () => {
+    render(<AdminLoginModal isOpen={true} onClose={mockOnClose} onSuccess={mockOnSuccess} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Close modal' }));
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('submits the form successfully and calls onSuccess', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ success: true })
+    });
+
+    render(<AdminLoginModal isOpen={true} onClose={mockOnClose} onSuccess={mockOnSuccess} />);
+
+    fireEvent.change(screen.getByLabelText('Admin Password'), { target: { value: 'secret' } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith('/api/auth', expect.objectContaining({
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password: 'secret' }),
+    }));
+
+    expect(mockOnSuccess).toHaveBeenCalledTimes(1);
+    expect(screen.getByLabelText('Admin Password')).toHaveValue(''); // Password should be cleared on success
+  });
+
+  it('displays an error message when authentication fails', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: 'Incorrect password' })
+    });
+
+    render(<AdminLoginModal isOpen={true} onClose={mockOnClose} onSuccess={mockOnSuccess} />);
+
+    fireEvent.change(screen.getByLabelText('Admin Password'), { target: { value: 'wrong' } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(mockOnSuccess).not.toHaveBeenCalled();
+    expect(await screen.findByText('Incorrect password')).toBeInTheDocument();
+  });
+
+  it('displays a fallback error message when authentication fails without a specific error', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({})
+    });
+
+    render(<AdminLoginModal isOpen={true} onClose={mockOnClose} onSuccess={mockOnSuccess} />);
+
+    fireEvent.change(screen.getByLabelText('Admin Password'), { target: { value: 'wrong' } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(await screen.findByText('Invalid password')).toBeInTheDocument();
+  });
+
+  it('displays an error message when the fetch request throws', async () => {
+    (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('Network error'));
+
+    render(<AdminLoginModal isOpen={true} onClose={mockOnClose} onSuccess={mockOnSuccess} />);
+
+    fireEvent.change(screen.getByLabelText('Admin Password'), { target: { value: 'secret' } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(await screen.findByText('An error occurred. Please try again.')).toBeInTheDocument();
+  });
+
+  it('disables buttons while submitting', async () => {
+    // Return a promise that doesn't resolve immediately to keep it in submitting state
+    let resolveFetch!: (value: unknown) => void;
+    const fetchPromise = new Promise(resolve => {
+        resolveFetch = resolve;
+    });
+
+    (global.fetch as jest.Mock).mockReturnValueOnce(fetchPromise);
+
+    render(<AdminLoginModal isOpen={true} onClose={mockOnClose} onSuccess={mockOnSuccess} />);
+
+    fireEvent.change(screen.getByLabelText('Admin Password'), { target: { value: 'secret' } });
+
+    // Use act to trigger the click which will set isSubmitting to true
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    });
+
+    // Check if buttons are disabled
+    expect(screen.getByRole('button', { name: 'Verifying...' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+
+    // Now resolve the fetch promise
+    await act(async () => {
+        resolveFetch({ ok: true, json: async () => ({}) });
+    });
+  });
+});

--- a/agent-context/tests.json
+++ b/agent-context/tests.json
@@ -74,6 +74,13 @@
       ]
     },
     {
+      "path": "__tests__/components/AdminLoginModal.test.tsx",
+      "kind": "test",
+      "covers": [
+        "app/components/AdminLoginModal.tsx"
+      ]
+    },
+    {
       "path": "__tests__/components/DashboardPage.test.tsx",
       "kind": "test",
       "covers": [
@@ -208,6 +215,9 @@
     ],
     "app/api/team-performance/route.ts": [
       "__tests__/api/team-performance.test.ts"
+    ],
+    "app/components/AdminLoginModal.tsx": [
+      "__tests__/components/AdminLoginModal.test.tsx"
     ],
     "app/components/AdminProvider.tsx": [
       "__tests__/components/DashboardPage.test.tsx",

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
[Shield 🛡️] Add unit tests for AdminLoginModal component

## What changed
Created `__tests__/components/AdminLoginModal.test.tsx` to add full test coverage for the `AdminLoginModal` component, covering rendering, successful/failed form submissions, error handling, and button states.

## Why
The `AdminLoginModal` component previously had 0% coverage. Adding tests ensures the critical admin authentication flow works as expected, improving application reliability and preventing regressions when the form or authentication API is modified.

## Validation
- [x] pnpm build ✅
- [x] pnpm test ✅
- [x] pnpm lint ✅
- [x] pnpm run context:check ✅
- [x] npx snyk code test ✅ (no new first-party code introduced/SNYK-0005)

---
*PR created automatically by Jules for task [16318154322209032948](https://jules.google.com/task/16318154322209032948) started by @kjschaef*