### PR TITLE
🛡️ Shield: [testing improvement] Add API tests for feedback route

### DIFF
--- a/__tests__/api/feedback.test.ts
+++ b/__tests__/api/feedback.test.ts
@@ -1,0 +1,117 @@
+import { NextRequest } from 'next/server';
+import { POST } from '../../app/api/feedback/route';
+
+describe('/api/feedback POST', () => {
+  let consoleLogSpy: jest.SpyInstance;
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterAll(() => {
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+  const createMockRequest = (body: any) => {
+    return {
+      json: async () => body,
+    } as unknown as NextRequest;
+  };
+
+  it('successfully processes valid feedback', async () => {
+    const validPayload = {
+      messageIndex: 1,
+      feedbackType: 'positive',
+      feedbackText: 'Great response!',
+      chatTranscript: [
+        { role: 'user', content: 'Hello', timestamp: '2024-03-20T10:00:00Z' },
+        { role: 'assistant', content: 'Hi there', timestamp: '2024-03-20T10:00:05Z' }
+      ]
+    };
+
+    const request = createMockRequest(validPayload);
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data).toEqual({
+      success: true,
+      message: 'Feedback submitted successfully'
+    });
+    expect(consoleLogSpy).toHaveBeenCalled();
+    const logCall = consoleLogSpy.mock.calls[0][0];
+    expect(logCall).toContain('Positive');
+    expect(logCall).toContain('Great response!');
+    expect(logCall).toContain('<-- FEEDBACK FOR THIS MESSAGE');
+  });
+
+  it('successfully processes negative feedback', async () => {
+    const validPayload = {
+      messageIndex: 0,
+      feedbackType: 'negative',
+      feedbackText: 'Not helpful',
+      chatTranscript: [
+        { role: 'assistant', content: 'I do not know', timestamp: '2024-03-20T10:00:05Z' }
+      ]
+    };
+
+    const request = createMockRequest(validPayload);
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(consoleLogSpy).toHaveBeenCalled();
+    const logCall = consoleLogSpy.mock.calls[0][0];
+    expect(logCall).toContain('Needs Improvement');
+    expect(logCall).toContain('Not helpful');
+  });
+
+  it('returns 400 when feedbackText is missing', async () => {
+    const invalidPayload = {
+      messageIndex: 1,
+      feedbackType: 'positive',
+      chatTranscript: []
+    };
+
+    const request = createMockRequest(invalidPayload);
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data).toEqual({ error: 'Feedback text is required' });
+    expect(consoleLogSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when feedbackText is empty or whitespace', async () => {
+    const invalidPayload = {
+      messageIndex: 1,
+      feedbackType: 'positive',
+      feedbackText: '   ',
+      chatTranscript: []
+    };
+
+    const request = createMockRequest(invalidPayload);
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data).toEqual({ error: 'Feedback text is required' });
+  });
+
+  it('returns 500 when JSON parsing fails', async () => {
+    const request = {
+      json: async () => { throw new Error('Invalid JSON'); }
+    } as unknown as NextRequest;
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(500);
+    const data = await response.json();
+    expect(data.error).toBe('Failed to submit feedback');
+    expect(data.details).toBe('Invalid JSON');
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+});

--- a/agent-context/tests.json
+++ b/agent-context/tests.json
@@ -16,6 +16,13 @@
       ]
     },
     {
+      "path": "__tests__/api/feedback.test.ts",
+      "kind": "test",
+      "covers": [
+        "app/api/feedback/route.ts"
+      ]
+    },
+    {
       "path": "__tests__/api/matches.test.ts",
       "kind": "test",
       "covers": [
@@ -183,6 +190,9 @@
     ],
     "app/api/daily-summary/route.ts": [
       "__tests__/api/daily-summary.test.ts"
+    ],
+    "app/api/feedback/route.ts": [
+      "__tests__/api/feedback.test.ts"
     ],
     "app/api/matches/route.ts": [
       "__tests__/api/matches.test.ts"

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
[Shield 🛡️] Add API route tests for /api/feedback

## What changed
Added a new Jest test suite `__tests__/api/feedback.test.ts` to verify the functionality of the `/api/feedback/route.ts` API route handler.

## Why
This improves test coverage and reliability by explicitly covering the happy paths for both positive and negative feedback submissions, as well as the error handling paths for missing text, empty text, and invalid JSON payloads.

## Validation
- [x] pnpm build ✅
- [x] pnpm test ✅
- [x] pnpm lint ✅
- [x] pnpm run context:check ✅
- [x] npx snyk code test ✅ (no new first-party code introduced beyond tests)

---
*PR created automatically by Jules for task [17670438716386294709](https://jules.google.com/task/17670438716386294709) started by @kjschaef*