### PR TITLE
🎨 Palette: [UX improvement] Improve accessibility of toggle buttons in PerformanceControls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -32,3 +32,7 @@
 ## 2024-05-22 - Selection Buttons and aria-pressed
 **Learning:** Even when buttons exist within specialized contexts (like a list of `players`), if they act as a toggle or selectable item, they *must* declare `aria-pressed` explicitly, otherwise screen readers cannot determine if the user has selected them.
 **Action:** Always add `aria-pressed={boolean}` and `focus-visible:ring-2` to buttons acting as interactive selection items in grids or lists.
+
+## 2024-05-18 - Avoid role="tablist" for generic toggle buttons
+**Learning:** Using `role="tablist"` on a container of metric toggles (like "Win %" vs "Total Wins") is actively harmful to screen reader users if full keyboard navigation (e.g. arrow keys moving focus between tabs) isn't implemented. Users expect native tab interaction and get confused when standard `<button>` elements are used inside without those handlers.
+**Action:** Replace `role="tablist"` with native, semantic toggle buttons using `aria-pressed={boolean}` and strong `focus-visible` styles (`focus-visible:ring-2 focus-visible:outline-none`). Add `focus-visible:z-10` to prevent adjacent button borders from clipping the focus ring.

--- a/app/components/PerformanceControls.tsx
+++ b/app/components/PerformanceControls.tsx
@@ -87,16 +87,18 @@ export function PerformanceControls({ season, metric, compare, showAllPlayers = 
 
         <div className="flex flex-col">
           <label id="metric-label" className="text-xs text-gray-500 mb-1">Metric</label>
-          <div className="inline-flex rounded-md shadow-sm bg-gray-100" role="tablist">
+          <div className="inline-flex rounded-md shadow-sm bg-gray-100">
             <button
+              aria-pressed={metric === 'winPercentage'}
               onClick={() => onChange({ metric: 'winPercentage' })}
-              className={`px-3 py-2 text-sm border-r ${metric === 'winPercentage' ? 'bg-gray-900 text-white border-gray-900' : 'bg-transparent text-gray-700 border-transparent'}`}
+              className={`px-3 py-2 text-sm border-r rounded-l-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:z-10 ${metric === 'winPercentage' ? 'bg-gray-900 text-white border-gray-900' : 'bg-transparent text-gray-700 border-transparent'}`}
             >
               Win %
             </button>
             <button
+              aria-pressed={metric === 'totalWins'}
               onClick={() => onChange({ metric: 'totalWins' })}
-              className={`px-3 py-2 text-sm ${metric === 'totalWins' ? 'bg-gray-900 text-white border-gray-900' : 'bg-transparent text-gray-700 border-transparent'}`}
+              className={`px-3 py-2 text-sm rounded-r-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:z-10 ${metric === 'totalWins' ? 'bg-gray-900 text-white border-gray-900' : 'bg-transparent text-gray-700 border-transparent'}`}
             >
               Total Wins
             </button>


### PR DESCRIPTION
🎨 Palette: [UX improvement] Improve accessibility of toggle buttons in PerformanceControls

## What changed
Refactored the metric selection buttons ("Win %" and "Total Wins") in `PerformanceControls.tsx` to use semantic `aria-pressed` toggle patterns instead of an incomplete `role="tablist"` implementation, and added proper keyboard focus ring styling.

## Why
Using `role="tablist"` without implementing the expected keyboard interactions (like arrow key navigation) creates a frustrating and confusing experience for screen reader users. Additionally, standard keyboard focus styling was missing, making the buttons difficult to navigate for keyboard-only users.

## Validation
- [x] pnpm build ✅
- [x] pnpm test ✅
- [x] pnpm lint ✅
- [x] pnpm run context:check ✅
- [x] npx snyk code test ✅ (or: no new first-party code introduced)

---
*PR created automatically by Jules for task [13969858768148675118](https://jules.google.com/task/13969858768148675118) started by @kjschaef*