### PR TITLE
[Shield 🛡️] Add unit tests for API routes

### DIFF
--- a/__tests__/api/auth-check.test.ts
+++ b/__tests__/api/auth-check.test.ts
@@ -1,0 +1,42 @@
+import { GET } from '@/app/api/auth/check/route';
+
+const mockCookieStore = {
+  get: jest.fn(),
+};
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn(() => mockCookieStore),
+}));
+
+describe('/api/auth/check GET', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns isAdmin: true when admin_token is present and equals "true"', async () => {
+    mockCookieStore.get.mockReturnValue({ value: 'true' });
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ isAdmin: true });
+    expect(mockCookieStore.get).toHaveBeenCalledWith('admin_token');
+  });
+
+  it('returns isAdmin: false when admin_token is not present', async () => {
+    mockCookieStore.get.mockReturnValue(undefined);
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ isAdmin: false });
+    expect(mockCookieStore.get).toHaveBeenCalledWith('admin_token');
+  });
+
+  it('returns isAdmin: false when admin_token does not equal "true"', async () => {
+    mockCookieStore.get.mockReturnValue({ value: 'false' });
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ isAdmin: false });
+    expect(mockCookieStore.get).toHaveBeenCalledWith('admin_token');
+  });
+});

--- a/__tests__/api/auth-logout.test.ts
+++ b/__tests__/api/auth-logout.test.ts
@@ -1,0 +1,23 @@
+import { POST } from '@/app/api/auth/logout/route';
+
+const mockCookieStore = {
+  delete: jest.fn(),
+};
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn(() => mockCookieStore),
+}));
+
+describe('/api/auth/logout POST', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deletes the admin_token cookie and returns success', async () => {
+    const response = await POST();
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ success: true });
+    expect(mockCookieStore.delete).toHaveBeenCalledWith('admin_token');
+  });
+});

--- a/__tests__/api/feedback.test.ts
+++ b/__tests__/api/feedback.test.ts
@@ -1,0 +1,111 @@
+import { NextRequest } from 'next/server';
+import { POST } from '@/app/api/feedback/route';
+
+describe('/api/feedback POST', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('rejects when feedbackText is missing', async () => {
+    const mockRequest = {
+      json: async () => ({
+        messageIndex: 0,
+        feedbackType: 'positive',
+        chatTranscript: []
+      })
+    } as unknown as NextRequest;
+
+    const response = await POST(mockRequest);
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: 'Feedback text is required' });
+    expect(console.log).not.toHaveBeenCalled();
+  });
+
+  it('rejects when feedbackText is just whitespace', async () => {
+    const mockRequest = {
+      json: async () => ({
+        messageIndex: 0,
+        feedbackType: 'positive',
+        feedbackText: '   \n  ',
+        chatTranscript: []
+      })
+    } as unknown as NextRequest;
+
+    const response = await POST(mockRequest);
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: 'Feedback text is required' });
+    expect(console.log).not.toHaveBeenCalled();
+  });
+
+  it('accepts valid negative feedback and formats transcript correctly', async () => {
+    const mockRequest = {
+      json: async () => ({
+        messageIndex: 1,
+        feedbackType: 'negative',
+        feedbackText: 'This answer is incorrect.',
+        chatTranscript: [
+          { role: 'user', content: 'What is the score?', timestamp: '2026-01-01T12:00:00.000Z' },
+          { role: 'assistant', content: 'The score is 5-5.', timestamp: '2026-01-01T12:00:01.000Z' },
+        ]
+      })
+    } as unknown as NextRequest;
+
+    const response = await POST(mockRequest);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      success: true,
+      message: 'Feedback submitted successfully'
+    });
+
+    // Check that console.log was called with the correct formatted text
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('FEEDBACK TYPE: Needs Improvement'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('MESSAGE INDEX: 1'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('This answer is incorrect.'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('USER: What is the score?'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('ASSISTANT: The score is 5-5. <-- FEEDBACK FOR THIS MESSAGE'));
+  });
+
+  it('accepts valid positive feedback', async () => {
+    const mockRequest = {
+      json: async () => ({
+        messageIndex: 0,
+        feedbackType: 'positive',
+        feedbackText: 'Great!',
+        chatTranscript: [
+          { role: 'assistant', content: 'Hello', timestamp: '2026-01-01T12:00:00.000Z' },
+        ]
+      })
+    } as unknown as NextRequest;
+
+    const response = await POST(mockRequest);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      success: true,
+      message: 'Feedback submitted successfully'
+    });
+
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('FEEDBACK TYPE: Positive'));
+  });
+
+  it('handles JSON parsing errors gracefully', async () => {
+    const mockRequest = {
+      json: async () => { throw new Error('Invalid JSON'); }
+    } as unknown as NextRequest;
+
+    const response = await POST(mockRequest);
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      error: 'Failed to submit feedback',
+      details: 'Invalid JSON'
+    });
+
+    // Check that console.error logged the failure
+    expect(console.error).toHaveBeenCalledWith('Error submitting feedback:', expect.any(Error));
+  });
+});

--- a/agent-context/tests.json
+++ b/agent-context/tests.json
@@ -2,6 +2,20 @@
   "schemaVersion": 1,
   "tests": [
     {
+      "path": "__tests__/api/auth-check.test.ts",
+      "kind": "test",
+      "covers": [
+        "app/api/auth/check/route.ts"
+      ]
+    },
+    {
+      "path": "__tests__/api/auth-logout.test.ts",
+      "kind": "test",
+      "covers": [
+        "app/api/auth/logout/route.ts"
+      ]
+    },
+    {
       "path": "__tests__/api/auth.test.ts",
       "kind": "test",
       "covers": [
@@ -13,6 +27,13 @@
       "kind": "test",
       "covers": [
         "app/api/daily-summary/route.ts"
+      ]
+    },
+    {
+      "path": "__tests__/api/feedback.test.ts",
+      "kind": "test",
+      "covers": [
+        "app/api/feedback/route.ts"
       ]
     },
     {
@@ -178,11 +199,20 @@
     }
   ],
   "coverageByFile": {
+    "app/api/auth/check/route.ts": [
+      "__tests__/api/auth-check.test.ts"
+    ],
+    "app/api/auth/logout/route.ts": [
+      "__tests__/api/auth-logout.test.ts"
+    ],
     "app/api/auth/route.ts": [
       "__tests__/api/auth.test.ts"
     ],
     "app/api/daily-summary/route.ts": [
       "__tests__/api/daily-summary.test.ts"
+    ],
+    "app/api/feedback/route.ts": [
+      "__tests__/api/feedback.test.ts"
     ],
     "app/api/matches/route.ts": [
       "__tests__/api/matches.test.ts"

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
[Shield 🛡️] Add unit tests for API routes

## What changed
Added unit tests covering the `/api/feedback`, `/api/auth/check`, and `/api/auth/logout` endpoints. This covers missing payload, invalid JSON, and missing/invalid cookie edge cases. 

## Why
Improves code reliability and regression safety for critical App Router handlers by validating HTTP response statuses and data shapes under various happy and unhappy paths, ensuring deterministic backend behaviors.

## Validation
- [x] pnpm build ✅
- [x] pnpm test ✅
- [x] pnpm lint ✅
- [x] pnpm run context:check ✅
- [x] npx snyk code test ✅ (no new first-party code introduced)

---
*PR created automatically by Jules for task [15255085547614132980](https://jules.google.com/task/15255085547614132980) started by @kjschaef*