### PR TITLE
[Shield 🛡️] Add unit tests for feedback API route

### DIFF
--- a/__tests__/api/feedback.test.ts
+++ b/__tests__/api/feedback.test.ts
@@ -1,0 +1,99 @@
+import { NextRequest } from 'next/server';
+import { POST } from '../../app/api/feedback/route';
+
+describe('Feedback API', () => {
+  let consoleLogSpy: jest.SpyInstance;
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+  const createMockRequest = (bodyObj: any) => {
+    return {
+      json: async () => bodyObj,
+    } as NextRequest;
+  };
+
+  const createMockRequestWithReject = () => {
+    return {
+      json: async () => Promise.reject(new Error('Invalid JSON')),
+    } as NextRequest;
+  };
+
+  it('should handle successful feedback submission', async () => {
+    const validPayload = {
+      messageIndex: 1,
+      feedbackType: 'positive',
+      feedbackText: 'Great answer!',
+      chatTranscript: [
+        { role: 'user', content: 'Hello', timestamp: new Date().toISOString() },
+        { role: 'assistant', content: 'Hi there', timestamp: new Date().toISOString() },
+      ]
+    };
+
+    const request = createMockRequest(validPayload);
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.success).toBe(true);
+    expect(data.message).toBe('Feedback submitted successfully');
+
+    expect(consoleLogSpy).toHaveBeenCalled();
+    const logCall = consoleLogSpy.mock.calls[0][0];
+    expect(logCall).toContain('New feedback received for the Volleyball Chat Assistant:');
+    expect(logCall).toContain('FEEDBACK TYPE: Positive');
+    expect(logCall).toContain('MESSAGE INDEX: 1');
+    expect(logCall).toContain('Great answer!');
+    expect(logCall).toContain('<-- FEEDBACK FOR THIS MESSAGE');
+  });
+
+  it('should return 400 Bad Request if feedbackText is missing', async () => {
+    const invalidPayload = {
+      messageIndex: 1,
+      feedbackType: 'positive',
+      chatTranscript: []
+    };
+
+    const request = createMockRequest(invalidPayload);
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toBe('Feedback text is required');
+  });
+
+  it('should return 400 Bad Request if feedbackText is empty or just whitespace', async () => {
+    const invalidPayload = {
+      messageIndex: 1,
+      feedbackType: 'positive',
+      feedbackText: '   ',
+      chatTranscript: []
+    };
+
+    const request = createMockRequest(invalidPayload);
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toBe('Feedback text is required');
+  });
+
+  it('should return 500 Internal Server Error if request.json() fails', async () => {
+    const request = createMockRequestWithReject();
+    const response = await POST(request);
+
+    expect(response.status).toBe(500);
+    const data = await response.json();
+    expect(data.error).toBe('Failed to submit feedback');
+    expect(data.details).toBe('Invalid JSON');
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Error submitting feedback:', expect.any(Error));
+  });
+});

--- a/agent-context/tests.json
+++ b/agent-context/tests.json
@@ -16,6 +16,13 @@
       ]
     },
     {
+      "path": "__tests__/api/feedback.test.ts",
+      "kind": "test",
+      "covers": [
+        "app/api/feedback/route.ts"
+      ]
+    },
+    {
       "path": "__tests__/api/matches.test.ts",
       "kind": "test",
       "covers": [
@@ -183,6 +190,9 @@
     ],
     "app/api/daily-summary/route.ts": [
       "__tests__/api/daily-summary.test.ts"
+    ],
+    "app/api/feedback/route.ts": [
+      "__tests__/api/feedback.test.ts"
     ],
     "app/api/matches/route.ts": [
       "__tests__/api/matches.test.ts"

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## What changed
Added a new Jest test suite (`__tests__/api/feedback.test.ts`) to cover the `app/api/feedback/route.ts` API endpoint.

## Why
To ensure the feedback mechanism properly processes incoming payloads and to test error handling for missing data and malformed JSON, making the chatbot analytics pipeline more robust.

## Validation
- [x] pnpm build ✅
- [x] pnpm test ✅
- [x] pnpm lint ✅
- [x] pnpm run context:check ✅
- [x] npx snyk code test ✅ (no new first-party code introduced, SNYK-0005 expected)

---
*PR created automatically by Jules for task [17940917476842062136](https://jules.google.com/task/17940917476842062136) started by @kjschaef*