### PR TITLE
🎨 Palette: Improve accessibility of metric toggle buttons in PerformanceControls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -32,3 +32,10 @@
 ## 2024-05-22 - Selection Buttons and aria-pressed
 **Learning:** Even when buttons exist within specialized contexts (like a list of `players`), if they act as a toggle or selectable item, they *must* declare `aria-pressed` explicitly, otherwise screen readers cannot determine if the user has selected them.
 **Action:** Always add `aria-pressed={boolean}` and `focus-visible:ring-2` to buttons acting as interactive selection items in grids or lists.
+## 2024-05-23 - Custom Tablist Containers
+**Learning:** Container s with `role="tablist"` frequently lack correct semantic children (`role="tab"`) and keyboard event listeners (arrow keys) expected by screen readers, making them inaccessible.
+**Action:** Unless implementing full custom tab keyboard navigation, remove `role="tablist"` and replace custom nested toggles with standard `<button>` elements. Ensure these buttons include `aria-pressed={boolean}` and appropriate focus styles (`focus-visible:ring`). When buttons are adjacent, use `focus-visible:z-10` to ensure focus rings are fully visible.
+
+## 2024-05-23 - Custom Tablist Containers
+**Learning:** Container `div`s with `role="tablist"` frequently lack correct semantic children (`role="tab"`) and keyboard event listeners (arrow keys) expected by screen readers, making them inaccessible.
+**Action:** Unless implementing full custom tab keyboard navigation, remove `role="tablist"` and replace custom nested toggles with standard `<button>` elements. Ensure these buttons include `aria-pressed={boolean}` and appropriate focus styles (`focus-visible:ring`). When buttons are adjacent, use `focus-visible:z-10` to ensure focus rings are fully visible.

--- a/app/components/PerformanceControls.tsx
+++ b/app/components/PerformanceControls.tsx
@@ -87,16 +87,18 @@ export function PerformanceControls({ season, metric, compare, showAllPlayers = 
 
         <div className="flex flex-col">
           <label id="metric-label" className="text-xs text-gray-500 mb-1">Metric</label>
-          <div className="inline-flex rounded-md shadow-sm bg-gray-100" role="tablist">
+          <div className="inline-flex rounded-md shadow-sm bg-gray-100" >
             <button
               onClick={() => onChange({ metric: 'winPercentage' })}
-              className={`px-3 py-2 text-sm border-r ${metric === 'winPercentage' ? 'bg-gray-900 text-white border-gray-900' : 'bg-transparent text-gray-700 border-transparent'}`}
+              aria-pressed={metric === 'winPercentage'}
+              className={`px-3 py-2 text-sm border-r rounded-l-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:z-10 ${metric === 'winPercentage' ? 'bg-gray-900 text-white border-gray-900' : 'bg-transparent text-gray-700 border-transparent'}`}
             >
               Win %
             </button>
             <button
               onClick={() => onChange({ metric: 'totalWins' })}
-              className={`px-3 py-2 text-sm ${metric === 'totalWins' ? 'bg-gray-900 text-white border-gray-900' : 'bg-transparent text-gray-700 border-transparent'}`}
+              aria-pressed={metric === 'totalWins'}
+              className={`px-3 py-2 text-sm rounded-r-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:z-10 ${metric === 'totalWins' ? 'bg-gray-900 text-white border-gray-900' : 'bg-transparent text-gray-700 border-transparent'}`}
             >
               Total Wins
             </button>


### PR DESCRIPTION
🎨 Palette: [UX improvement]

## 💡 What
Modified the 'Metric' toggle selector in the Dashboard's `PerformanceControls` component. Removed the invalid `role="tablist"` wrapper and added `aria-pressed` state attributes to the individual `<button>` toggles, along with improved `focus-visible` styling (`focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:z-10` and explicit border radii).

## 🎯 Why
Container `div`s with `role="tablist"` expect complex ARIA keyboard interactions (arrow keys instead of tabs) and specific child roles (`role="tab"`). This was causing screen readers to misinterpret the buttons. Converting them to simple standard toggles with `aria-pressed` corrects the accessible tree semantics while improving native keyboard focus visibility so users can reliably navigate and understand the control's selection state.

## 📸 Before/After
*(Visuals attached via frontend verification video)*
- Focus rings are now correctly visible without being clipped by the adjacent button's border due to `z-10`.
- Outer rounded corners align correctly on the focus ring boundary.

## ♿ Accessibility
- Removed improperly formatted `role="tablist"` container.
- Implemented `aria-pressed` attributes matching the state of the component logic.
- Expanded native keyboard support through explicit `focus-visible` utility classes.

---
*PR created automatically by Jules for task [4278127221549330047](https://jules.google.com/task/4278127221549330047) started by @kjschaef*