### PR TITLE
[Shield 🛡️] Add unit tests for /api/feedback route

### DIFF
--- a/__tests__/api/feedback.test.ts
+++ b/__tests__/api/feedback.test.ts
@@ -1,0 +1,136 @@
+import { NextRequest } from 'next/server';
+import { POST } from '../../app/api/feedback/route';
+
+// Helper to create a NextRequest mock
+const createMockRequest = (body: any, rejectJson = false) => {
+  return {
+    json: jest.fn().mockImplementation(() => {
+      if (rejectJson) {
+        return Promise.reject(new Error('Invalid JSON'));
+      }
+      return Promise.resolve(body);
+    }),
+  } as unknown as NextRequest;
+};
+
+describe('POST /api/feedback', () => {
+  const originalConsoleLog = console.log;
+  const originalConsoleError = console.error;
+  let mockConsoleLog: jest.Mock;
+  let mockConsoleError: jest.Mock;
+
+  beforeEach(() => {
+    mockConsoleLog = jest.fn();
+    mockConsoleError = jest.fn();
+    console.log = mockConsoleLog;
+    console.error = mockConsoleError;
+  });
+
+  afterEach(() => {
+    console.log = originalConsoleLog;
+    console.error = originalConsoleError;
+  });
+
+  it('returns 400 Bad Request when feedbackText is missing', async () => {
+    const request = createMockRequest({
+      messageIndex: 1,
+      feedbackType: 'negative',
+      chatTranscript: []
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data).toEqual({ error: 'Feedback text is required' });
+  });
+
+  it('returns 400 Bad Request when feedbackText is empty or just whitespace', async () => {
+    const request = createMockRequest({
+      messageIndex: 1,
+      feedbackType: 'negative',
+      feedbackText: '   ',
+      chatTranscript: []
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data).toEqual({ error: 'Feedback text is required' });
+  });
+
+  it('processes feedback successfully and logs properly formatted output', async () => {
+    const request = createMockRequest({
+      messageIndex: 1,
+      feedbackType: 'negative',
+      feedbackText: 'This response was not helpful.',
+      chatTranscript: [
+        {
+          role: 'user',
+          content: 'Hello',
+          timestamp: '2023-10-25T10:00:00Z'
+        },
+        {
+          role: 'assistant',
+          content: 'How can I help?',
+          timestamp: '2023-10-25T10:00:05Z'
+        }
+      ]
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({ success: true, message: 'Feedback submitted successfully' });
+
+    // Verify logging format
+    expect(mockConsoleLog).toHaveBeenCalledTimes(1);
+    const logOutput = mockConsoleLog.mock.calls[0][0];
+
+    expect(logOutput).toContain('FEEDBACK TYPE: Needs Improvement');
+    expect(logOutput).toContain('MESSAGE INDEX: 1');
+    expect(logOutput).toContain('This response was not helpful.');
+    expect(logOutput).toContain('USER: Hello');
+    expect(logOutput).toContain('ASSISTANT: How can I help? <-- FEEDBACK FOR THIS MESSAGE');
+  });
+
+  it('processes positive feedback correctly', async () => {
+    const request = createMockRequest({
+      messageIndex: 0,
+      feedbackType: 'positive',
+      feedbackText: 'Great answer!',
+      chatTranscript: [
+        {
+          role: 'assistant',
+          content: 'I am a helpful assistant.',
+          timestamp: '2023-10-25T10:00:00Z'
+        }
+      ]
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+
+    expect(mockConsoleLog).toHaveBeenCalledTimes(1);
+    const logOutput = mockConsoleLog.mock.calls[0][0];
+    expect(logOutput).toContain('FEEDBACK TYPE: Positive');
+  });
+
+  it('returns 500 Internal Server Error when an exception occurs', async () => {
+    const request = createMockRequest(null, true);
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data).toEqual({
+      error: 'Failed to submit feedback',
+      details: 'Invalid JSON'
+    });
+
+    expect(mockConsoleError).toHaveBeenCalledTimes(1);
+    expect(mockConsoleError).toHaveBeenCalledWith('Error submitting feedback:', expect.any(Error));
+  });
+});

--- a/agent-context/tests.json
+++ b/agent-context/tests.json
@@ -16,6 +16,13 @@
       ]
     },
     {
+      "path": "__tests__/api/feedback.test.ts",
+      "kind": "test",
+      "covers": [
+        "app/api/feedback/route.ts"
+      ]
+    },
+    {
       "path": "__tests__/api/matches.test.ts",
       "kind": "test",
       "covers": [
@@ -190,6 +197,9 @@
     ],
     "app/api/daily-summary/route.ts": [
       "__tests__/api/daily-summary.test.ts"
+    ],
+    "app/api/feedback/route.ts": [
+      "__tests__/api/feedback.test.ts"
     ],
     "app/api/matches/route.ts": [
       "__tests__/api/matches.test.ts"


### PR DESCRIPTION
## What changed
Added a new unit test suite for the `app/api/feedback/route.ts` API route in `__tests__/api/feedback.test.ts`. This tests both positive and negative feedback success scenarios (including transcript log validation), and missing/empty text validation rules (returning HTTP 400).

## Why
This route lacked test coverage entirely. Adding these tests increases our App Router API coverage, ensures that feedback logging functions correctly, and prevents regression of validation logic if this endpoint is refactored to support database persistence later. Mocks were used to ensure the tests don't pollute standard out with artificial console.log lines during routine testing.

## Validation
- [x] pnpm build ✅
- [x] pnpm test ✅
- [x] pnpm lint ✅
- [x] pnpm run context:check ✅
- [x] npx snyk code test ✅ (no new first-party code introduced / bypassed via SNYK-0005)

---
*PR created automatically by Jules for task [18020916197696095656](https://jules.google.com/task/18020916197696095656) started by @kjschaef*