### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded admin password fallback

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-25 - Hardcoded Default Admin Password
+**Vulnerability:** The application had a literal `'admin'` password fallback in `app/api/auth/route.ts` and `app/api/settings/route.ts`. If the database entry was empty or unconfigured, it allowed access with this default password.
+**Learning:** Hardcoding default credentials creates a significant risk as attackers will predictably try common passwords like `'admin'`. It also undermines the security of having an environment variable fallback (`ADMIN_PASSWORD`).
+**Prevention:** Never hardcode default passwords in authentication logic. Ensure that if no valid credential exists (either in the DB or as an environment variable), authentication explicitly fails. When initializing settings, insert `null` instead of a default string to enforce proper credential configuration.

--- a/app/api/auth/route.ts
+++ b/app/api/auth/route.ts
@@ -20,9 +20,9 @@ export async function POST(request: Request) {
     if (settings.length > 0 && settings[0].admin_password_hash) {
       // Simple string comparison for light security
       isValid = body.password === settings[0].admin_password_hash;
-    } else {
+    } else if (process.env.ADMIN_PASSWORD) {
       // Fallback if settings table is empty
-      isValid = body.password === (process.env.ADMIN_PASSWORD || 'admin');
+      isValid = body.password === process.env.ADMIN_PASSWORD;
     }
 
     if (isValid) {

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -97,7 +97,7 @@ export async function PUT(request: Request) {
           ${body.signupCloseDayOfWeek ?? 0},
           ${normalizedCloseTime},
           ${JSON.stringify(body.availableDays || DEFAULT_SIGNUP_SETTINGS.availableDays)},
-          ${body.adminPassword || 'admin'}
+          ${body.adminPassword || null}
         )
       `;
     }


### PR DESCRIPTION
[Shield 🛡️] Fix hardcoded admin password fallback

## What changed
Removed the hardcoded literal `'admin'` fallback in `app/api/auth/route.ts` when validating passwords, explicitly relying on `process.env.ADMIN_PASSWORD` instead. Also updated `app/api/settings/route.ts` to insert `null` instead of `'admin'` when creating default site settings if no password is provided.

## Why
Hardcoding a default fallback password creates a critical vulnerability. Attackers frequently test common defaults (like 'admin'), allowing unauthorized administrative access. Ensuring the app requires properly configured credentials (via DB or environment variable) secures the system and prevents unauthorized configuration changes.

## Validation
- [x] pnpm build ✅
- [x] pnpm test ✅
- [x] pnpm lint ✅
- [x] pnpm run context:check ✅
- [x] npx snyk code test ✅ (or: no new first-party code introduced)

---
*PR created automatically by Jules for task [6500627584745452122](https://jules.google.com/task/6500627584745452122) started by @kjschaef*