### PR TITLE
🎨 Palette: [UX improvement] Add focus indicators to inline interactive elements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -40,3 +40,6 @@
 ## 2024-05-23 - Metric Toggle Buttons and tablist
 **Learning:** Container elements for sets of toggle buttons (like "Win %" and "Total Wins" in metric selectors) are often mistakenly given `role="tablist"`. Unless these implement full keyboard arrow navigation per W3C ARIA tab patterns, they will fail accessibility checks or be confusing for screen reader users.
 **Action:** Remove `role="tablist"` from simple inline button groups. Instead, use standard `<button>` elements equipped with `aria-pressed={boolean}` and strong keyboard focus styles (`focus-visible:ring-2`, `focus-visible:z-10` to prevent clipping, and appropriate border radius `rounded-l-md/rounded-r-md` to match the container).
+## 2024-05-25 - Add explicit focus indicators to inline interactive components
+**Learning:** React elements rendered as `<button>` via array mapping or within inline text blocks (e.g. "Read full report" links styled as buttons) often lack clear visual indication of keyboard focus in Tailwind projects unless explicit `focus-visible:ring` classes are applied, creating a trap for keyboard navigators.
+**Action:** Always append `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1` along with a brand-appropriate ring color to all mapped choices and text-inline interactive buttons.

--- a/app/components/AISummaryPanel.tsx
+++ b/app/components/AISummaryPanel.tsx
@@ -67,7 +67,7 @@ export function AISummaryPanel({ onAskAI }: AISummaryPanelProps) {
                 {onAskAI && (
                     <button
                         onClick={onAskAI}
-                        className="text-xs font-medium text-indigo-600 hover:text-indigo-800 flex items-center gap-1 transition-colors"
+                        className="text-xs font-medium text-indigo-600 hover:text-indigo-800 flex items-center gap-1 transition-colors rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-1"
                     >
                         Read full report <span aria-hidden="true">&rarr;</span>
                     </button>

--- a/app/components/ChatBot.tsx
+++ b/app/components/ChatBot.tsx
@@ -814,7 +814,8 @@ export function ChatBot({ onUseMatchup, onRecordMatch, isOpen: controlledIsOpen,
                         <button
                           key={player}
                           onClick={() => handlePlayerChoice(amb.letter, player)}
-                          className={`px-3 py-1 rounded text-sm font-medium transition-colors ${isSelected
+                          aria-pressed={isSelected}
+                          className={`px-3 py-1 rounded text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yellow-500 focus-visible:ring-offset-1 ${isSelected
                             ? 'bg-yellow-500 text-white'
                             : 'bg-yellow-100 text-yellow-800 hover:bg-yellow-200'
                             }`}


### PR DESCRIPTION
## 💡 What
Added missing `focus-visible:ring` styling and `aria-pressed` states to the dynamic inline choice buttons inside `ChatBot.tsx` and the inline "Read full report" button in `AISummaryPanel.tsx`.

## 🎯 Why
React components rendered inline or over arrays using semantic `<button>` elements often lacked the proper Tailwind focus classes, making keyboard navigation confusing or impossible. These explicit indicators prevent keyboard navigation traps and improve usability.

## 📸 Before/After
*(Visual changes add a yellow or indigo ring to the buttons when focused via keyboard)*

## ♿ Accessibility
- Added `aria-pressed` to the ambiguous player choice toggle buttons.
- Added `focus-visible` styles to multiple interactive buttons that were missing clear visual keyboard focus indicators.

---
*PR created automatically by Jules for task [18439927103661033379](https://jules.google.com/task/18439927103661033379) started by @kjschaef*