### PR TITLE
🛡️ Shield: Fix flaky navigation and smoke tests by using semantic locator

### DIFF
--- a/.jules/shield.md
+++ b/.jules/shield.md
@@ -20,3 +20,7 @@
 ## 2024-05-24 - Environment Variable Manipulation in Jest
 **Learning:** In Next.js App Router API testing, deleting required environment variables (like `DATABASE_URL`) without a fail-safe restoration block will silently pollute the process environment and cause subsequent tests to fail unexpectedly, since `process.env` mutations are global across the suite.
 **Action:** Always wrap code blocks that manipulate or delete global environment variables in a `try...finally` block, ensuring variables are explicitly restored in the `finally` statement so they reset even if assertions throw errors.
+
+## 2025-05-27 - Playwright Strict Mode violation with Next.js App Router
+**Learning:** When asserting the visibility of basic HTML tags like `nav` or `header` in Next.js App Router using Playwright, relying on simple `page.locator('nav')` or `page.getByRole('navigation')` may fail due to strict mode violations in development or CI environments. The Next.js development tools inject an error overlay (e.g. `<nav class="error-overlay-pagination">`) that also matches standard locators, causing `locator('nav')` to resolve to multiple elements.
+**Action:** Always refine semantic locators in Playwright by filtering for specific application text (e.g., `page.getByRole('navigation').filter({ hasText: 'App Title' })`) or by using explicit test IDs or semantic ARIA labels, instead of relying solely on the element role or tag name.

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -6,23 +6,26 @@ test.describe('Navigation', () => {
   });
 
   test('should navigate to all main pages', async ({ page }) => {
-    // Current Navbar should have links (verify it exists)
-    await expect(page.locator('nav')).toBeVisible();
+    // Current Navbar should have links (verify it exists). We use exact match or filter
+    // to avoid strict mode violations from Next.js dev tools overlay navigation.
+    const nav = page.getByRole('navigation').filter({ hasText: 'Wallyball League' });
+    await expect(nav).toBeVisible();
 
-    // Check Dashboard
-    await page.click('text=Dashboard');
+    // The click targets need to be specific to avoid matching other links on the page.
+    // Dashboard page
+    await nav.getByRole('link', { name: 'Dashboard' }).click();
     await expect(page).toHaveURL(/.*\/$/); // Dashboard is the root page
 
-    // Check Results
-    await page.click('text=Results');
+    // Results page
+    await nav.getByRole('link', { name: 'Results' }).click();
     await expect(page).toHaveURL(/\/results/);
 
-    // Check Signups
-    await page.click('text=Signups');
+    // Signups page
+    await nav.getByRole('link', { name: 'Signups', exact: true }).click();
     await expect(page).toHaveURL(/\/signups/);
 
-    // Check Settings
-    await page.click('text=Settings');
+    // Settings page
+    await nav.getByRole('link', { name: 'Settings', exact: true }).click();
     await expect(page).toHaveURL(/\/settings/);
   });
 });

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -7,8 +7,8 @@ test('has title and basic dashboard elements', async ({ page }) => {
   // Expect a title "to contain" a substring.
   await expect(page, 'Page should have Wallyball title').toHaveTitle(/Wallyball/i);
 
-  // Check for the navbar
-  await expect(page.locator('nav')).toBeVisible();
+  // Check for the navbar (filter to avoid matching Next.js dev tools overlay)
+  await expect(page.getByRole('navigation').filter({ hasText: 'Wallyball League' })).toBeVisible();
 
   // Wait for application content to ensure we are not on a login or error page
   await expect(page.getByRole('heading', { name: 'Win Percentage' })).toBeVisible({ timeout: 30000 });


### PR DESCRIPTION
Updated Playwright locators in `smoke.spec.ts` and `navigation.spec.ts` to filter the `navigation` role by specific text or use exact link names. Added an entry to `.jules/shield.md` to document this testing pattern.

When testing Next.js applications in a development or CI environment, the Next.js dev tools occasionally inject an error or warning overlay (e.g. `<nav class="error-overlay-pagination">`) into the DOM. This causes simple locators like `locator('nav')` or `getByRole('navigation')` to throw a strict mode violation error because they resolve to multiple elements. Explicitly scoping the navigation locators makes the E2E tests robust against these dev overlays.

---
*PR created automatically by Jules for task [15263218760465242168](https://jules.google.com/task/15263218760465242168) started by @kjschaef*