### PR TITLE
[Shield 🛡️] Suppress expected console.error logs in API tests

### DIFF
--- a/__tests__/api/daily-summary.test.ts
+++ b/__tests__/api/daily-summary.test.ts
@@ -53,17 +53,25 @@ jest.mock('@/lib/seasons', () => ({
 
 import { GET } from '@/app/api/daily-summary/route';
 
+let consoleSpy: jest.SpyInstance;
+
 describe('/api/daily-summary GET', () => {
   const originalDatabaseUrl = process.env.DATABASE_URL;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // Suppress expected console.error logs to clean up test output
+    consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     process.env.DATABASE_URL = 'mock-database-url';
     mockGetCurrentSeasonByDate.mockReturnValue({
       start_date: '2026-01-01T00:00:00.000Z',
       end_date: '2026-03-31T23:59:59.000Z',
     });
     mockSql.mockImplementation(() => Promise.resolve([]));
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
   });
 
   afterAll(() => {

--- a/__tests__/api/player-trends.test.ts
+++ b/__tests__/api/player-trends.test.ts
@@ -24,14 +24,18 @@ jest.mock('@neondatabase/serverless', () => ({
 
 
 const { neon } = require('@neondatabase/serverless') as { neon: jest.Mock };
+let consoleSpy: jest.SpyInstance;
 const originalDbUrl = process.env.DATABASE_URL;
 
 beforeEach(() => {
+  // Suppress expected console.error logs to clean up test output
+  consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
   process.env.DATABASE_URL = 'mock-db-url';
   jest.clearAllMocks();
 });
 
 afterEach(() => {
+  consoleSpy.mockRestore();
   process.env.DATABASE_URL = originalDbUrl;
   jest.useRealTimers();
 });

--- a/__tests__/api/settings.test.ts
+++ b/__tests__/api/settings.test.ts
@@ -41,14 +41,22 @@ jest.mock('next/headers', () => ({
 
 import { GET, PUT } from '@/app/api/settings/route';
 
+let consoleSpy: jest.SpyInstance;
+
 describe('/api/settings', () => {
   const originalDatabaseUrl = process.env.DATABASE_URL;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // Suppress expected console.error logs to clean up test output
+    consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     process.env.DATABASE_URL = 'mock-database-url';
     mockCookieStore.get.mockReturnValue(undefined);
     mockSql.mockImplementation(() => Promise.resolve([]));
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
   });
 
   afterAll(() => {


### PR DESCRIPTION
## What changed
Added `jest.spyOn(console, 'error')` with a no-op mock implementation to `settings.test.ts`, `daily-summary.test.ts`, and `player-trends.test.ts` to suppress expected console.error logs, and ensured the mocks are restored after each test.

## Why
These test suites intentionally trigger error paths that the API routes log via `console.error`. Mocking this expected output prevents test execution from polluting the terminal output with noise, making actual test failures easier to identify and debug, improving the overall reliability of our CI output.

## Validation
- [x] pnpm build ✅
- [x] pnpm test ✅
- [x] pnpm lint ✅
- [x] pnpm run context:check ✅
- [x] npx snyk code test ✅ (or: no new first-party code introduced)

---
*PR created automatically by Jules for task [13340234971994004706](https://jules.google.com/task/13340234971994004706) started by @kjschaef*