### PR TITLE
🛡️ Shield: Fix missing try...finally blocks for environment variable restoration in tests

### DIFF
--- a/__tests__/api/daily-summary.test.ts
+++ b/__tests__/api/daily-summary.test.ts
@@ -191,11 +191,16 @@ describe('/api/daily-summary GET', () => {
   });
 
   it('returns 500 when the route cannot initialize', async () => {
+    const originalDatabaseUrl = process.env.DATABASE_URL;
     delete process.env.DATABASE_URL;
 
-    const response = await GET();
+    try {
+      const response = await GET();
 
-    expect(response.status).toBe(500);
-    await expect(response.json()).resolves.toEqual({ error: 'Failed to generate summary' });
+      expect(response.status).toBe(500);
+      await expect(response.json()).resolves.toEqual({ error: 'Failed to generate summary' });
+    } finally {
+      process.env.DATABASE_URL = originalDatabaseUrl;
+    }
   });
 });

--- a/__tests__/api/matches.test.ts
+++ b/__tests__/api/matches.test.ts
@@ -335,15 +335,17 @@ describe('/api/matches', () => {
       const originalUrl = process.env.DATABASE_URL;
       delete process.env.DATABASE_URL;
 
-      const request = new NextRequest('http://localhost:3000/api/matches');
-      const response = await GET(request);
+      try {
+        const request = new NextRequest('http://localhost:3000/api/matches');
+        const response = await GET(request);
 
-      expect(response.status).toBe(500);
-      const data = await response.json();
-      expect(data).toEqual({ error: 'Failed to fetch matches' });
-
-      // Restore environment variable
-      process.env.DATABASE_URL = originalUrl;
+        expect(response.status).toBe(500);
+        const data = await response.json();
+        expect(data).toEqual({ error: 'Failed to fetch matches' });
+      } finally {
+        // Restore environment variable
+        process.env.DATABASE_URL = originalUrl;
+      }
     });
 
     it('should handle stats=true with database error', async () => {

--- a/__tests__/api/player-stats.test.ts
+++ b/__tests__/api/player-stats.test.ts
@@ -430,15 +430,17 @@ describe('/api/player-stats', () => {
       const originalUrl = process.env.DATABASE_URL;
       delete process.env.DATABASE_URL;
 
-      const request = new NextRequest('http://localhost:3000/api/player-stats');
-      const response = await GET(request);
+      try {
+        const request = new NextRequest('http://localhost:3000/api/player-stats');
+        const response = await GET(request);
 
-      expect(response.status).toBe(500);
-      const data = await response.json();
-      expect(data).toEqual({ error: 'Failed to fetch player statistics' });
-
-      // Restore environment variable
-      process.env.DATABASE_URL = originalUrl;
+        expect(response.status).toBe(500);
+        const data = await response.json();
+        expect(data).toEqual({ error: 'Failed to fetch player statistics' });
+      } finally {
+        // Restore environment variable
+        process.env.DATABASE_URL = originalUrl;
+      }
     });
 
     it('should validate total game counts across multiple complex match scenarios', async () => {

--- a/__tests__/api/player-trends.test.ts
+++ b/__tests__/api/player-trends.test.ts
@@ -41,14 +41,16 @@ describe('/api/player-trends', () => {
     const originalUrl = process.env.DATABASE_URL;
     delete process.env.DATABASE_URL;
 
-    const request = new NextRequest('http://localhost:3000/api/player-trends');
-    const response = await GET(request);
-    const data = await response.json();
+    try {
+      const request = new NextRequest('http://localhost:3000/api/player-trends');
+      const response = await GET(request);
+      const data = await response.json();
 
-    expect(response.status).toBe(500);
-    expect(data).toEqual({ error: 'Failed to fetch player trends' });
-
-    process.env.DATABASE_URL = originalUrl;
+      expect(response.status).toBe(500);
+      expect(data).toEqual({ error: 'Failed to fetch player trends' });
+    } finally {
+      process.env.DATABASE_URL = originalUrl;
+    }
   });
 
   it('returns 400 when an invalid season string is provided', async () => {

--- a/__tests__/api/seasons.test.ts
+++ b/__tests__/api/seasons.test.ts
@@ -52,18 +52,23 @@ describe('/api/seasons', () => {
     });
 
     it('falls back to computed seasons when DATABASE_URL is not set', async () => {
+      const originalUrl = process.env.DATABASE_URL;
       delete process.env.DATABASE_URL;
-      jest.useFakeTimers().setSystemTime(new Date('2025-02-15T00:00:00.000Z').getTime());
+      try {
+        jest.useFakeTimers().setSystemTime(new Date('2025-02-15T00:00:00.000Z').getTime());
 
-      const request = new NextRequest('http://localhost:3000/api/seasons');
-      const response = await getSeasonsRoute(request);
-      const data = await response.json();
+        const request = new NextRequest('http://localhost:3000/api/seasons');
+        const response = await getSeasonsRoute(request);
+        const data = await response.json();
 
-      expect(response.status).toBe(200);
-      expect(data.length).toBe(17); // 12 computed + lifetime + annuals
-      expect(data[0]).toMatchObject({ name: '2025 Q1', is_active: true });
-      expect(data[data.length - 1]).toMatchObject({ name: 'Lifetime', id: 0 });
-      expect(neon).not.toHaveBeenCalled();
+        expect(response.status).toBe(200);
+        expect(data.length).toBe(17); // 12 computed + lifetime + annuals
+        expect(data[0]).toMatchObject({ name: '2025 Q1', is_active: true });
+        expect(data[data.length - 1]).toMatchObject({ name: 'Lifetime', id: 0 });
+        expect(neon).not.toHaveBeenCalled();
+      } finally {
+        process.env.DATABASE_URL = originalUrl;
+      }
     });
 
     it('handles database errors gracefully', async () => {


### PR DESCRIPTION
[Shield 🛡️] Fix missing try...finally blocks for environment variable restoration

## What changed
Wrapped the deletion and restoration of `process.env.DATABASE_URL` in `try...finally` blocks across five API test files (`daily-summary`, `matches`, `player-stats`, `player-trends`, and `seasons`). 

## Why
Deleting required environment variables without a fail-safe restoration block will silently pollute the process environment and cause subsequent tests to fail unexpectedly if assertions throw errors. This ensures the test suite remains deterministic and robust.

## Validation
- [x] pnpm build ✅
- [x] pnpm test ✅
- [x] pnpm lint ✅
- [x] pnpm run context:check ✅
- [x] npx snyk code test ✅ (no new first-party code introduced)

---
*PR created automatically by Jules for task [3776292047468130045](https://jules.google.com/task/3776292047468130045) started by @kjschaef*