### PR TITLE
🎨 Palette: Add aria-pressed to ChatBot player selection

### DIFF
--- a/app/components/ChatBot.tsx
+++ b/app/components/ChatBot.tsx
@@ -813,8 +813,10 @@ export function ChatBot({ onUseMatchup, onRecordMatch, isOpen: controlledIsOpen,
                       return (
                         <button
                           key={player}
+                          type="button"
+                          aria-pressed={isSelected}
                           onClick={() => handlePlayerChoice(amb.letter, player)}
-                          className={`px-3 py-1 rounded text-sm font-medium transition-colors ${isSelected
+                          className={`px-3 py-1 rounded text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yellow-500 focus-visible:ring-offset-1 ${isSelected
                             ? 'bg-yellow-500 text-white'
                             : 'bg-yellow-100 text-yellow-800 hover:bg-yellow-200'
                             }`}


### PR DESCRIPTION
## 💡 What
Added `type="button"`, `aria-pressed={isSelected}`, and explicit keyboard focus indicators (`focus-visible:ring-2 focus-visible:ring-yellow-500 focus-visible:ring-offset-1`) to the dynamically generated player choice buttons in `app/components/ChatBot.tsx`.

## 🎯 Why
These buttons act as toggle switches for selecting player ambiguity clarifications. Without `aria-pressed`, screen readers could not determine which option was actively selected. Furthermore, relying entirely on hover states without `focus-visible` meant keyboard-only users could easily get lost and be unable to distinguish which option had visual focus. Setting `type="button"` also explicitly prevents unintended form submissions if these are ever inadvertently nested within a form.

## 📸 Before/After
*(Visual change is purely the addition of standard yellow keyboard focus rings upon Tab navigation)*

## ♿ Accessibility
- Explicit state management using `aria-pressed` for assistive technologies.
- Robust, WCAG-compliant keyboard focus visibility using Tailwind's `focus-visible` utility.
- Prevents implicit `<button type="submit">` behavior.

---
*PR created automatically by Jules for task [5596997167514310843](https://jules.google.com/task/5596997167514310843) started by @kjschaef*