### PR TITLE
🎨 Palette: Contextual ARIA Labels and Focus Styles for List Action Buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -40,3 +40,7 @@
 ## 2024-05-23 - Metric Toggle Buttons and tablist
 **Learning:** Container elements for sets of toggle buttons (like "Win %" and "Total Wins" in metric selectors) are often mistakenly given `role="tablist"`. Unless these implement full keyboard arrow navigation per W3C ARIA tab patterns, they will fail accessibility checks or be confusing for screen reader users.
 **Action:** Remove `role="tablist"` from simple inline button groups. Instead, use standard `<button>` elements equipped with `aria-pressed={boolean}` and strong keyboard focus styles (`focus-visible:ring-2`, `focus-visible:z-10` to prevent clipping, and appropriate border radius `rounded-l-md/rounded-r-md` to match the container).
+
+## 2024-06-04 - Contextual ARIA Labels for List Action Buttons
+**Learning:** Icon-only delete or action buttons within mapped lists (like waitlists or player signups) are often given generic `aria-label` or `title` attributes (e.g., "Remove player"). This forces screen reader users to rely on surrounding DOM context to determine *which* item is being removed, and visual users lack clear tooltip feedback.
+**Action:** Always interpolate the specific item's name or identifier into the `aria-label` and `title` for list action buttons (e.g., `aria-label={"Remove " + player.name}`). Additionally, ensure these inline action buttons have explicit `focus-visible:ring` states.

--- a/__tests__/components/SignupsPage.test.tsx
+++ b/__tests__/components/SignupsPage.test.tsx
@@ -133,7 +133,7 @@ describe('SignupsPage', () => {
     });
 
     // Wait for the specific element to appear to signify rendering is complete
-    const removePlayerButtons = await screen.findAllByTitle('Remove player');
+    const removePlayerButtons = await screen.findAllByTitle('Remove Bob from signup list');
     expect(removePlayerButtons).toHaveLength(1);
 
     // Use findByText for assertion to ensure it's fully rendered
@@ -146,6 +146,6 @@ describe('SignupsPage', () => {
     });
 
     // Using findByTitle waits for the fetch requests to resolve and state to update
-    expect(await screen.findByTitle('Remove unavailable player')).toBeInTheDocument();
+    expect(await screen.findByTitle('Remove Alice from unavailable list')).toBeInTheDocument();
   });
 });

--- a/app/signups/page.tsx
+++ b/app/signups/page.tsx
@@ -345,8 +345,8 @@ export default function SignupsPage() {
                     <span>{player.name}</span>
                     <button
                       onClick={() => handleRemoveUnavailable(player.id)}
-                      className="rounded-full p-1 text-rose-400 transition-colors hover:bg-rose-50 hover:text-rose-600"
-                      title="Remove unavailable player"
+                      className="rounded-full p-1 text-rose-400 transition-colors hover:bg-rose-50 hover:text-rose-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-500 focus-visible:ring-offset-1"
+                      title={`Remove ${player.name} from unavailable list`}
                       aria-label={`Remove ${player.name} from unavailable list`}
                     >
                       <Trash2 className="h-3.5 w-3.5" />
@@ -403,8 +403,9 @@ export default function SignupsPage() {
                             </div>
                             <button
                               onClick={() => handleDelete(signup.id)}
-                              className="text-red-400 hover:text-red-600 p-2 rounded-md hover:bg-red-50"
-                              title="Remove player"
+                              className="text-red-400 hover:text-red-600 p-2 rounded-md hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-1"
+                              title={`Remove ${signup.name} from signup list`}
+                              aria-label={`Remove ${signup.name} from signup list`}
                             >
                               <Trash2 className="w-4 h-4" />
                             </button>
@@ -425,7 +426,9 @@ export default function SignupsPage() {
                             <span>{idx + 1}. {signup.name}</span>
                             <button
                               onClick={() => handleDelete(signup.id)}
-                              className="text-orange-400 hover:text-orange-600 p-1 rounded hover:bg-orange-100"
+                              className="text-orange-400 hover:text-orange-600 p-1 rounded hover:bg-orange-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:ring-offset-1"
+                              title={`Remove ${signup.name} from waitlist`}
+                              aria-label={`Remove ${signup.name} from waitlist`}
                             >
                               <Trash2 className="w-3 h-3" />
                             </button>


### PR DESCRIPTION
[Palette 🎨] Improve UX and accessibility for list action buttons in signups

## What changed
Added specific `aria-label`s, `title`s (interpolating the player's name), and visible focus ring styles to the icon-only remove/delete buttons across all three lists on the Signups page (unavailable, registered, and waitlist). Updated related unit tests. Documented this finding in `.Jules/palette.md`.

## Why
Icon-only list action buttons with generic labels (like "Remove player") force screen reader users to rely on surrounding DOM structure to guess *which* list item is being removed. Interpolating the player's name (e.g., "Remove Alice from waitlist") gives explicit context. Additionally, clear keyboard focus styles improve accessibility for keyboard-only users.

## Validation
- [x] pnpm build ✅
- [x] pnpm test ✅
- [x] pnpm lint ✅
- [x] pnpm run context:check ✅
- [x] npx snyk code test ✅ (Failed with SNYK-0005, skipped per guidelines since no new first-party code was introduced)

---
*PR created automatically by Jules for task [586092663873698438](https://jules.google.com/task/586092663873698438) started by @kjschaef*