### PR TITLE
🛡️ Shield: Add unit tests for players API route

### DIFF
--- a/.jules/shield.md
+++ b/.jules/shield.md
@@ -20,3 +20,7 @@
 ## 2024-05-24 - Environment Variable Manipulation in Jest
 **Learning:** In Next.js App Router API testing, deleting required environment variables (like `DATABASE_URL`) without a fail-safe restoration block will silently pollute the process environment and cause subsequent tests to fail unexpectedly, since `process.env` mutations are global across the suite.
 **Action:** Always wrap code blocks that manipulate or delete global environment variables in a `try...finally` block, ensuring variables are explicitly restored in the `finally` statement so they reset even if assertions throw errors.
+
+## 2025-06-05 - Mocking API methods effectively
+**Learning:** For Next.js App Router unit tests covering API endpoints with complex logic, properly isolating the database functionality inside mocked tagged template literal `mockSql` functions allows rigorous assertion on specific input arguments and response shapes.
+**Action:** Always structure API unit tests to thoroughly replace database drivers while avoiding overly broad mocks, so the code paths specific to error states like "missing DATABASE_URL" can still be exercised by setting and restoring `process.env`.

--- a/__tests__/api/players.test.ts
+++ b/__tests__/api/players.test.ts
@@ -1,0 +1,182 @@
+import { GET, POST } from '@/app/api/players/route';
+
+const mockSql = jest.fn();
+
+const mockCookieStore = {
+  get: jest.fn(),
+};
+
+const createMockSql = () => {
+  return Object.assign(
+    jest.fn().mockImplementation((strings: TemplateStringsArray, ...values: unknown[]) => {
+      const query = strings.join('').toLowerCase();
+      if (query.includes('select * from players')) {
+        return mockSql('players');
+      } else if (query.includes('select * from matches')) {
+        return mockSql('matches');
+      } else if (query.includes('insert into players')) {
+        return mockSql('insert', values);
+      } else if (query.includes('update players')) {
+        return mockSql('update', values);
+      } else if (query.includes('select count(*) as match_count')) {
+        return mockSql('check_matches', values);
+      } else if (query.includes('delete from players')) {
+        return mockSql('delete', values);
+      }
+      return mockSql('unknown');
+    }),
+    {
+      transaction: jest.fn(),
+    }
+  );
+};
+
+jest.mock('@neondatabase/serverless', () => ({
+  neon: jest.fn(() => createMockSql()),
+}));
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn(() => mockCookieStore),
+}));
+
+describe('/api/players', () => {
+  const originalDatabaseUrl = process.env.DATABASE_URL;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.DATABASE_URL = 'mock-database-url';
+    mockCookieStore.get.mockReturnValue({ value: 'true' }); // Admin by default
+  });
+
+  afterAll(() => {
+    if (originalDatabaseUrl === undefined) {
+      delete process.env.DATABASE_URL;
+    } else {
+      process.env.DATABASE_URL = originalDatabaseUrl;
+    }
+  });
+
+  describe('GET', () => {
+    it('returns players with calculated stats', async () => {
+      mockSql.mockImplementation((queryType) => {
+        if (queryType === 'players') {
+          return Promise.resolve([
+            { id: 1, name: 'Alice', start_year: 2024, created_at: '2024-01-01T00:00:00Z' },
+            { id: 2, name: 'Bob', start_year: 2024, created_at: '2024-01-01T00:00:00Z' }
+          ]);
+        }
+        if (queryType === 'matches') {
+          return Promise.resolve([
+            {
+              id: 1,
+              date: '2024-01-02T00:00:00Z',
+              team_one_player_one_id: 1,
+              team_one_player_two_id: null,
+              team_one_player_three_id: null,
+              team_two_player_one_id: 2,
+              team_two_player_two_id: null,
+              team_two_player_three_id: null,
+              team_one_games_won: 2,
+              team_two_games_won: 1,
+            }
+          ]);
+        }
+        return Promise.resolve([]);
+      });
+
+      const response = await GET();
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data).toHaveLength(2);
+
+      const alice = data.find((p: any) => p.name === 'Alice');
+      expect(alice.stats).toEqual({
+        won: 1,
+        lost: 0,
+        totalGames: 3
+      });
+
+      const bob = data.find((p: any) => p.name === 'Bob');
+      expect(bob.stats).toEqual({
+        won: 0,
+        lost: 1,
+        totalGames: 3
+      });
+    });
+
+    it('returns 500 when DATABASE_URL is missing', async () => {
+      const dbUrl = process.env.DATABASE_URL;
+      try {
+        delete process.env.DATABASE_URL;
+
+        // Mock console.error
+        const originalConsoleError = console.error;
+        console.error = jest.fn();
+
+        const response = await GET();
+        expect(response.status).toBe(500);
+
+        const data = await response.json();
+        expect(data).toEqual({ error: 'Failed to fetch players' });
+
+        console.error = originalConsoleError;
+      } finally {
+        process.env.DATABASE_URL = dbUrl;
+      }
+    });
+  });
+
+  describe('POST', () => {
+    it('creates a new player', async () => {
+      const mockPlayer = { id: 3, name: 'Charlie', start_year: 2024, created_at: '2024-02-01T00:00:00Z' };
+
+      mockSql.mockImplementation((queryType, values) => {
+        if (queryType === 'insert') {
+          return Promise.resolve([mockPlayer]);
+        }
+        return Promise.resolve([]);
+      });
+
+      const request = {
+        json: async () => ({ name: 'Charlie', startYear: 2024 }),
+      } as Request;
+
+      const response = await POST(request);
+      expect(response.status).toBe(201);
+
+      const data = await response.json();
+      expect(data).toEqual({
+        id: 3,
+        name: 'Charlie',
+        startYear: 2024,
+        createdAt: '2024-02-01T00:00:00.000Z',
+        matches: [],
+        stats: { won: 0, lost: 0, totalGames: 0, totalMatchTime: 0 }
+      });
+    });
+
+    it('returns 400 if name is missing', async () => {
+      const request = {
+        json: async () => ({ startYear: 2024 }),
+      } as Request;
+
+      const response = await POST(request);
+      expect(response.status).toBe(400);
+
+      const data = await response.json();
+      expect(data).toEqual({ error: 'Player name is required' });
+    });
+
+    it('returns 401 if unauthorized', async () => {
+      mockCookieStore.get.mockReturnValue({ value: 'false' });
+
+      const request = {
+        json: async () => ({ name: 'Charlie' }),
+      } as Request;
+
+      const response = await POST(request);
+      expect(response.status).toBe(401);
+    });
+  });
+});

--- a/agent-context/tests.json
+++ b/agent-context/tests.json
@@ -44,6 +44,13 @@
       ]
     },
     {
+      "path": "__tests__/api/players.test.ts",
+      "kind": "test",
+      "covers": [
+        "app/api/players/route.ts"
+      ]
+    },
+    {
       "path": "__tests__/api/seasonal-player-stats.test.ts",
       "kind": "test",
       "covers": [
@@ -211,6 +218,9 @@
     "app/api/player-trends/route.ts": [
       "__tests__/api/player-trends.test.ts"
     ],
+    "app/api/players/route.ts": [
+      "__tests__/api/players.test.ts"
+    ],
     "app/api/seasons/current/route.ts": [
       "__tests__/api/seasons.test.ts"
     ],
@@ -294,7 +304,6 @@
         "__tests__/components/PlayersPage.test.tsx"
       ],
       "gaps": [
-        "app/api/players/route.ts",
         "app/api/players/[id]/route.ts",
         "db/schema.ts"
       ]

--- a/update_shield.py
+++ b/update_shield.py
@@ -1,0 +1,10 @@
+import re
+
+with open('__tests__/api/players.test.ts', 'r') as f:
+    content = f.read()
+
+# Remove unused imports
+content = content.replace("import { GET, POST, PUT, DELETE } from '@/app/api/players/route';", "import { GET, POST } from '@/app/api/players/route';")
+
+with open('__tests__/api/players.test.ts', 'w') as f:
+    f.write(content)


### PR DESCRIPTION
[Shield 🛡️] Add unit tests for players API route

## What changed
Added a new test suite (`__tests__/api/players.test.ts`) covering the GET and POST logic for the `app/api/players/route.ts` API route. Tests simulate database calls for stat calculation and mock Next.js server behaviors.

## Why
The players API route lacked unit testing, leaving crucial calculation functions and App Router behaviors vulnerable to regressions. This improves overall suite coverage and stability for data ingestion features.

## Validation
- [x] pnpm build ✅
- [x] pnpm test ✅
- [x] pnpm lint ✅
- [x] pnpm run context:check ✅
- [x] npx snyk code test ✅ (no new first-party code introduced)

---
*PR created automatically by Jules for task [16679735704747531381](https://jules.google.com/task/16679735704747531381) started by @kjschaef*