### PR TITLE
🎨 Palette: [UX improvement] Match History icon button accessibility

### DIFF
--- a/app/games/page.tsx
+++ b/app/games/page.tsx
@@ -161,8 +161,9 @@ export default function GamesPage() {
             {playerFilter && (
               <button
                 onClick={() => setPlayerFilter("")}
-                className="absolute right-2 top-1/2 transform -translate-y-1/2 p-1 hover:bg-gray-100 rounded-full"
+                className="absolute right-2 top-1/2 transform -translate-y-1/2 p-1 hover:bg-gray-100 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                 title="Clear search"
+                aria-label="Clear player search"
               >
                 <X className="h-3 w-3 text-gray-400" />
               </button>
@@ -200,7 +201,8 @@ export default function GamesPage() {
               Player: &quot;{playerFilter}&quot;
               <button
                 onClick={() => setPlayerFilter("")}
-                className="hover:bg-blue-200 rounded-full p-0.5"
+                className="hover:bg-blue-200 rounded-full p-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                aria-label="Remove player filter"
               >
                 <X className="h-3 w-3" />
               </button>
@@ -214,7 +216,8 @@ export default function GamesPage() {
                   setFromDate("");
                   setToDate("");
                 }}
-                className="hover:bg-green-200 rounded-full p-0.5"
+                className="hover:bg-green-200 rounded-full p-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-500"
+                aria-label="Remove date filter"
               >
                 <X className="h-3 w-3" />
               </button>
@@ -284,8 +287,9 @@ export default function GamesPage() {
 
                       <button
                         onClick={() => handleDeleteMatch(match.id)}
-                        className="p-1 text-gray-400 hover:text-red-500 transition-colors"
+                        className="p-1 text-gray-400 hover:text-red-500 transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
                         title="Delete match"
+                        aria-label="Delete match"
                       >
                         <Trash2 className="h-4 w-4" />
                       </button>


### PR DESCRIPTION
🎨 Palette: Accessibility improvements for Match History icon buttons

## 💡 What
Added proper `aria-label`s and visible keyboard focus states (`focus-visible:ring`) to the four icon-only buttons on the Match History page:
1. Clear player search button
2. Remove player filter pill button
3. Remove date filter pill button
4. Delete match button

## 🎯 Why
Icon-only buttons present severe barriers for both screen reader users (who cannot determine the button's action without a text label) and keyboard-only users (who cannot easily tell when an element has focus if no visual indicator is provided).

## 📸 Before/After
Before: Icon buttons lacked accessible text and focus rings.
After: Buttons are properly announced by screen readers and show a clear blue/green/red focus ring (depending on context) when navigated via keyboard.

## ♿ Accessibility
- Added `aria-label` to communicate button intent to assistive technologies.
- Added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color]` to provide clear, accessible focus states during keyboard navigation.

## Validation
- [x] pnpm build ✅
- [x] pnpm test ✅
- [x] pnpm lint ✅
- [x] pnpm run context:check ✅
- [x] npx snyk code test ✅ (no new first-party code introduced)

---
*PR created automatically by Jules for task [6140471759561720496](https://jules.google.com/task/6140471759561720496) started by @kjschaef*