### PR TITLE
[Shield 🛡️] Add unit tests for signup utility functions

### DIFF
--- a/app/lib/__tests__/signups.test.ts
+++ b/app/lib/__tests__/signups.test.ts
@@ -1,5 +1,5 @@
-import { format } from 'date-fns';
-import {
+import { format } from "date-fns";
+import { parseAvailableDays, normalizeTimeInputValue, parseTime,
   generateWeekDates,
   getSignupCycleState,
   isDateInSignupWeek,
@@ -49,5 +49,71 @@ describe('signup cycle utilities', () => {
     ]);
     expect(isDateInSignupWeek('2026-01-19', signupWeekSunday, defaultSettings.availableDays)).toBe(true);
     expect(isDateInSignupWeek('2026-01-21', signupWeekSunday, defaultSettings.availableDays)).toBe(false);
+  });
+});
+
+describe('parseAvailableDays', () => {
+  it('returns default available days when given null or undefined', () => {
+    expect(parseAvailableDays(null)).toEqual(defaultSettings.availableDays);
+    expect(parseAvailableDays(undefined)).toEqual(defaultSettings.availableDays);
+    expect(parseAvailableDays('')).toEqual(defaultSettings.availableDays);
+  });
+
+  it('returns parsed array when given valid JSON array of strings', () => {
+    const validJson = JSON.stringify(['Monday', 'Wednesday', 'Friday']);
+    expect(parseAvailableDays(validJson)).toEqual(['Monday', 'Wednesday', 'Friday']);
+  });
+
+  it('returns default available days when given invalid JSON', () => {
+    expect(parseAvailableDays('invalid json')).toEqual(defaultSettings.availableDays);
+  });
+
+  it('returns default available days when given a non-array JSON object', () => {
+    expect(parseAvailableDays(JSON.stringify({ day: 'Monday' }))).toEqual(defaultSettings.availableDays);
+  });
+
+  it('returns default available days when given an array with non-string elements', () => {
+    expect(parseAvailableDays(JSON.stringify(['Monday', 1, true]))).toEqual(defaultSettings.availableDays);
+  });
+});
+
+describe('normalizeTimeInputValue', () => {
+  it('returns fallback for null, undefined, or empty string', () => {
+    expect(normalizeTimeInputValue(null, '12:00')).toBe('12:00');
+    expect(normalizeTimeInputValue(undefined, '12:00')).toBe('12:00');
+    expect(normalizeTimeInputValue('', '12:00')).toBe('12:00');
+  });
+
+  it('returns fallback for completely invalid formats', () => {
+    expect(normalizeTimeInputValue('invalid', '12:00')).toBe('12:00');
+    expect(normalizeTimeInputValue('12-00', '12:00')).toBe('12:00');
+    expect(normalizeTimeInputValue('1:00', '12:00')).toBe('12:00'); // Requires HH:MM
+  });
+
+  it('normalizes valid HH:MM strings', () => {
+    expect(normalizeTimeInputValue('14:30', '12:00')).toBe('14:30');
+    expect(normalizeTimeInputValue('09:05', '12:00')).toBe('09:05');
+  });
+
+  it('returns fallback for out-of-range times', () => {
+    expect(normalizeTimeInputValue('25:00', '12:00')).toBe('12:00');
+    expect(normalizeTimeInputValue('-1:00', '12:00')).toBe('12:00');
+    expect(normalizeTimeInputValue('12:60', '12:00')).toBe('12:00');
+  });
+});
+
+describe('parseTime', () => {
+  it('parses basic HH:MM strings into numbers', () => {
+    expect(parseTime('14:30')).toEqual({ hours: 14, minutes: 30 });
+    expect(parseTime('09:05')).toEqual({ hours: 9, minutes: 5 });
+  });
+
+  it('handles empty strings by returning zeros', () => {
+    expect(parseTime('')).toEqual({ hours: 0, minutes: 0 });
+  });
+
+  it('handles invalid numbers by returning zeros', () => {
+    expect(parseTime('aa:bb')).toEqual({ hours: 0, minutes: 0 });
+    expect(parseTime('NaN:NaN')).toEqual({ hours: 0, minutes: 0 });
   });
 });


### PR DESCRIPTION
## What changed
Added unit tests covering the edge cases, parsing correctness, and null/undefined handling for `parseAvailableDays`, `normalizeTimeInputValue`, and `parseTime` functions in `app/lib/signups.ts`.

## Why
These core utility functions handle critical input processing for signups. Providing comprehensive test coverage for these specific parsers ensures reliable data normalization, preventing invalid inputs from polluting the signup configuration or crashing the API.

## Validation
- [x] pnpm build ✅
- [x] pnpm test ✅
- [x] pnpm lint ✅
- [x] pnpm run context:check ✅
- [x] npx snyk code test ✅ (no new first-party code introduced)

---
*PR created automatically by Jules for task [5454556933898980856](https://jules.google.com/task/5454556933898980856) started by @kjschaef*