### PR TITLE
🎨 Palette: [UX improvement] Add focus states and ARIA to disambiguation buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -40,3 +40,7 @@
 ## 2024-05-23 - Metric Toggle Buttons and tablist
 **Learning:** Container elements for sets of toggle buttons (like "Win %" and "Total Wins" in metric selectors) are often mistakenly given `role="tablist"`. Unless these implement full keyboard arrow navigation per W3C ARIA tab patterns, they will fail accessibility checks or be confusing for screen reader users.
 **Action:** Remove `role="tablist"` from simple inline button groups. Instead, use standard `<button>` elements equipped with `aria-pressed={boolean}` and strong keyboard focus styles (`focus-visible:ring-2`, `focus-visible:z-10` to prevent clipping, and appropriate border radius `rounded-l-md/rounded-r-md` to match the container).
+
+## 2024-06-07 - Dynamic Toggle Buttons Accessibility
+**Learning:** Custom dynamic toggle buttons generated during interactions (like disambiguating players) are often missed during accessibility sweeps. They require both `aria-pressed` states to communicate their status to screen readers and distinct focus styles (`focus-visible`) for keyboard navigability.
+**Action:** When implementing custom dynamic toggle buttons, ensure they have `aria-pressed` bound to their selection state and include explicit `focus-visible` utility classes for clear keyboard focus indicators.

--- a/app/components/ChatBot.tsx
+++ b/app/components/ChatBot.tsx
@@ -814,7 +814,8 @@ export function ChatBot({ onUseMatchup, onRecordMatch, isOpen: controlledIsOpen,
                         <button
                           key={player}
                           onClick={() => handlePlayerChoice(amb.letter, player)}
-                          className={`px-3 py-1 rounded text-sm font-medium transition-colors ${isSelected
+                          aria-pressed={isSelected}
+                          className={`px-3 py-1 rounded text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-yellow-500 ${isSelected
                             ? 'bg-yellow-500 text-white'
                             : 'bg-yellow-100 text-yellow-800 hover:bg-yellow-200'
                             }`}


### PR DESCRIPTION
## What changed
Added `aria-pressed` and `focus-visible` Tailwind classes to the dynamically generated player choice buttons in the `PlayerDisambiguationCard` component (`app/components/ChatBot.tsx`).

## Why
When the chatbot prompts the user to select between players with similar names, the dynamically rendered buttons acted as toggles but lacked ARIA states, meaning screen readers couldn't identify if a player was selected. They also lacked explicit focus rings, creating keyboard navigation traps where users couldn't see which button they were focused on.

## Validation
- [x] pnpm build ✅
- [x] pnpm test ✅
- [x] pnpm lint ✅
- [x] pnpm run context:check ✅
- [x] npx snyk code test ✅ (Bypassed due to SNYK-0005, no new first-party backend logic introduced)

## Accessibility
Added explicit `aria-pressed` binding for selection state tracking and `focus-visible:ring-2 focus-visible:ring-yellow-500` for clear keyboard focus indicators.

---
*PR created automatically by Jules for task [17100700122551202686](https://jules.google.com/task/17100700122551202686) started by @kjschaef*