### PR TITLE
🎨 Palette: [UX improvement] Fix label-has-associated-control accessibility issues in PerformanceControls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -40,3 +40,6 @@
 ## 2024-05-23 - Metric Toggle Buttons and tablist
 **Learning:** Container elements for sets of toggle buttons (like "Win %" and "Total Wins" in metric selectors) are often mistakenly given `role="tablist"`. Unless these implement full keyboard arrow navigation per W3C ARIA tab patterns, they will fail accessibility checks or be confusing for screen reader users.
 **Action:** Remove `role="tablist"` from simple inline button groups. Instead, use standard `<button>` elements equipped with `aria-pressed={boolean}` and strong keyboard focus styles (`focus-visible:ring-2`, `focus-visible:z-10` to prevent clipping, and appropriate border radius `rounded-l-md/rounded-r-md` to match the container).
+## 2024-06-09 - Custom Input Label Associations
+**Learning:** Using a `<label>` element without a native `<input>` (e.g., for custom button groups acting as a selector) triggers ESLint `jsx-a11y/label-has-associated-control` errors and provides poor support for screen readers.
+**Action:** When a label describes a custom component or a group of buttons instead of a native input, use a styled `<span>` or `<div>` with an `id`. Then use `role="group"` on the container and associate the label text using `aria-labelledby="[id-of-span]"`. Also, when using third-party components like `react-select`, properly link labels using the `inputId` prop.

--- a/app/components/PerformanceControls.tsx
+++ b/app/components/PerformanceControls.tsx
@@ -70,8 +70,9 @@ export function PerformanceControls({ season, metric, compare, showAllPlayers = 
     <div className="controls bg-white shadow-sm rounded-md p-4">
       <div className="primary flex flex-wrap items-end gap-4">
         <div className="flex flex-col">
-          <label id="season-label" className="text-xs text-gray-500 mb-1">Season</label>
+          <label htmlFor="season-select" className="text-xs text-gray-500 mb-1">Season</label>
           <select
+            id="season-select"
             aria-label="Season"
             className="w-56 bg-gray-50 border border-gray-200 px-3 py-2 rounded-md text-sm h-10"
             value={selectedSeason || 'current'}
@@ -86,8 +87,8 @@ export function PerformanceControls({ season, metric, compare, showAllPlayers = 
         </div>
 
         <div className="flex flex-col">
-          <label id="metric-label" className="text-xs text-gray-500 mb-1">Metric</label>
-          <div className="inline-flex rounded-md shadow-sm bg-gray-100">
+          <span id="metric-label" className="text-xs text-gray-500 mb-1 block">Metric</span>
+          <div className="inline-flex rounded-md shadow-sm bg-gray-100" role="group" aria-labelledby="metric-label">
             <button
               aria-pressed={metric === 'winPercentage'}
               onClick={() => onChange({ metric: 'winPercentage' })}
@@ -108,9 +109,10 @@ export function PerformanceControls({ season, metric, compare, showAllPlayers = 
         {/* Penalties and smoothing controls removed */}
 
         <div className="flex flex-col" style={{ minWidth: 220 }}>
-          <label id="compare-label" className="text-xs text-gray-500 mb-1">Compare</label>
+          <label htmlFor="compare-select" className="text-xs text-gray-500 mb-1">Compare</label>
           <div>
             <Select
+              inputId="compare-select"
               isMulti
               options={players.map(p => ({ value: p.id, label: p.name }))}
               classNamePrefix="react-select"


### PR DESCRIPTION
## 💡 What
Fixed several unassociated labels in the `PerformanceControls` component. For native `<select>` controls and `react-select`, `<label>` elements were properly linked using `id`/`htmlFor` and `inputId`. For the "Metric" custom button group, the invalid `<label>` was replaced with a `<span>` and the button container was updated to act as a `role="group"` with `aria-labelledby`.

## 🎯 Why
Labels without associated form controls trigger accessibility violations (`jsx-a11y/label-has-associated-control`) and confuse screen readers, as users with assistive technologies cannot programmatically associate the text with the interactive element.

## 📸 Before/After
No visual changes. Purely semantic HTML and ARIA attribute enhancements.

## ♿ Accessibility
- Improved screen reader association for native dropdowns and custom components.
- Grouped related segmented controls with a single accessible name.

## Validation
- [x] pnpm build ✅
- [x] pnpm test ✅
- [x] pnpm lint ✅
- [x] pnpm run context:check ✅
- [x] npx snyk code test ✅ (skipped due to auth error, no new code)

---
*PR created automatically by Jules for task [11610914121252777320](https://jules.google.com/task/11610914121252777320) started by @kjschaef*